### PR TITLE
feat(v2-to-v4): bigNumberNoopConverter

### DIFF
--- a/packages/converter-runtime/src/loadConverters.ts
+++ b/packages/converter-runtime/src/loadConverters.ts
@@ -29,11 +29,10 @@ async function doLoad(converters: Array<TypeConverterConfig>): Promise<Array<Run
             for (let convId of conv.use) {
               const loaded = module[convId];
               if (!loaded) {
-                throw new Error(`Use of converter with id "${convId}" of module "${conv.module}" failed!`);
+                throw new Error(`Converter with id "${convId}" doesn't exist in module "${conv.module}"!`);
               }
               converters.push(loaded);
             }
-            // console.log(`Dynamically imported [${conv.use.join(",")}] from converter package ${conv.module}`);
           }
           // use converter list from default export
           else {
@@ -42,7 +41,6 @@ async function doLoad(converters: Array<TypeConverterConfig>): Promise<Array<Run
               throw new Error(`Default export of loaded module "${conv.module}" doesn't conform to specification!`);
             }
             const pkg = candidate as ConverterPackage;
-            // console.log(`Dynamically loaded converter package ${conv.module} with id "${id}"`);
             converters = pkg.converters;
           }
 

--- a/packages/converter-runtime/test/ChainedCoverter.test.ts
+++ b/packages/converter-runtime/test/ChainedCoverter.test.ts
@@ -1,11 +1,27 @@
-import { numberToStringConverter, stringToPrefixModelConverter } from "@odata2ts/test-converters";
+import {
+  booleanToNumberConverter,
+  numberToStringConverter,
+  stringToPrefixModelConverter,
+} from "@odata2ts/test-converters";
 
-import { createChain } from "../src";
+import { ChainedConverter, createChain } from "../src";
 
 describe("ChainedConverter Test", () => {
   test("from number to prefixed string and back", () => {
     const toTest = createChain(numberToStringConverter, stringToPrefixModelConverter);
     expect(toTest.convertFrom(3)).toStrictEqual({ prefix: "PREFIX_", value: "3" });
     expect(toTest.convertTo({ prefix: "PREFIX", value: "22" })).toBe(22);
+  });
+
+  test("with ChainedConverter", () => {
+    const toTest = new ChainedConverter(numberToStringConverter, stringToPrefixModelConverter);
+    expect(toTest.convertFrom(3)).toStrictEqual({ prefix: "PREFIX_", value: "3" });
+    expect(toTest.convertTo({ prefix: "PREFIX", value: "22" })).toBe(22);
+  });
+
+  test("from number to prefixed string and back", () => {
+    const toTest = createChain(booleanToNumberConverter, numberToStringConverter).chain(stringToPrefixModelConverter);
+    expect(toTest.convertFrom(false)).toStrictEqual({ prefix: "PREFIX_", value: "0" });
+    expect(toTest.convertTo({ prefix: "PREFIX", value: "1" })).toBe(true);
   });
 });

--- a/packages/converter-runtime/test/ChainedCoverter.test.ts
+++ b/packages/converter-runtime/test/ChainedCoverter.test.ts
@@ -3,11 +3,9 @@ import { numberToStringConverter, stringToPrefixModelConverter } from "@odata2ts
 import { createChain } from "../src";
 
 describe("ChainedConverter Test", () => {
-  const toTest = createChain(numberToStringConverter, stringToPrefixModelConverter);
-
   test("from number to prefixed string and back", () => {
+    const toTest = createChain(numberToStringConverter, stringToPrefixModelConverter);
     expect(toTest.convertFrom(3)).toStrictEqual({ prefix: "PREFIX_", value: "3" });
     expect(toTest.convertTo({ prefix: "PREFIX", value: "22" })).toBe(22);
   });
-
 });

--- a/packages/converter-runtime/test/loadConverter.test.ts
+++ b/packages/converter-runtime/test/loadConverter.test.ts
@@ -7,8 +7,8 @@ describe("LoadConverters Test", () => {
   const V2_TO_V4_PKG = "@odata2ts/converter-v2-to-v4";
   const LUXON_PKG = "@odata2ts/converter-luxon";
 
-  // time, dateTime, byte, sByte, single, double
-  const V2_TO_V4_CONVERTERS_SIZE = 6;
+  // time, dateTime, byte, sByte, single, double, int64, decimal
+  const V2_TO_V4_CONVERTERS_SIZE = 8;
 
   test("no converters", async () => {
     const result = await loadConverters(ODataVersions.V4, undefined);
@@ -48,7 +48,6 @@ describe("LoadConverters Test", () => {
   test("specify installed converters without using any of them", async () => {
     const result = await loadConverters(ODataVersions.V4, [{ module: V2_TO_V4_PKG, use: [] }]);
 
-    // all string number types would still be mapped, but not Edm.Time and Edm.DateTime
     expect(result).toBeUndefined();
   });
 
@@ -56,7 +55,6 @@ describe("LoadConverters Test", () => {
     const converterIds = ["timeToTimeOfDayConverter", "dateTimeToDateTimeOffsetConverter"];
     const result = await loadConverters(ODataVersions.V2, [{ module: V2_TO_V4_PKG, use: converterIds }]);
 
-    // all string number types would still be mapped, but not Edm.Time and Edm.DateTime
     expect(result).toBeDefined();
     expect(result?.size).toBe(converterIds.length);
     expect(result?.get(ODataTypesV2.Time)).toStrictEqual({
@@ -72,6 +70,36 @@ describe("LoadConverters Test", () => {
     } as ValueConverterChain);
   });
 
+  test("last converter overrides some types of first converter", async () => {
+    const converterIds = ["stringToNumberConverter", "bigNumberNoopConverter"];
+    let result = await loadConverters(ODataVersions.V2, [{ module: V2_TO_V4_PKG, use: [converterIds[0]] }]);
+    expect(result?.get(ODataTypesV2.Decimal)).toStrictEqual({
+      from: ODataTypesV2.Decimal,
+      to: "number",
+      toModule: undefined,
+      converters: [
+        {
+          package: V2_TO_V4_PKG,
+          converterId: converterIds[0],
+        },
+      ],
+    });
+
+    result = await loadConverters(ODataVersions.V2, [{ module: V2_TO_V4_PKG, use: converterIds }]);
+
+    expect(result?.get(ODataTypesV2.Decimal)).toStrictEqual({
+      from: ODataTypesV2.Decimal,
+      to: "string",
+      toModule: undefined,
+      converters: [
+        {
+          package: V2_TO_V4_PKG,
+          converterId: converterIds[1],
+        },
+      ],
+    });
+  });
+
   test("fail to load converter", async () => {
     const fakeModule = "xxxxNotExistentxxxx";
     const expectedError = new Error(`Failed to load module "${fakeModule}"!`);
@@ -85,7 +113,7 @@ describe("LoadConverters Test", () => {
     const modules = [V2_TO_V4_PKG, LUXON_PKG];
 
     const result = await loadConverters(ODataVersions.V2, modules);
-    expect(result?.size).toBe(7);
+    expect(result?.size).toBe(9);
 
     const dateTimeToLuxon = result?.get(ODataTypesV2.DateTime);
     expect(dateTimeToLuxon).toStrictEqual({

--- a/packages/converter-ui5-v2/src/index.ts
+++ b/packages/converter-ui5-v2/src/index.ts
@@ -1,6 +1,10 @@
 import { ConverterPackage } from "@odata2ts/converter-api";
 import { dateTimeOffsetToDateConverter } from "@odata2ts/converter-common";
-import { dateTimeToDateTimeOffsetConverter, stringToNumberConverter } from "@odata2ts/converter-v2-to-v4";
+import {
+  bigNumberNoopConverter,
+  dateTimeToDateTimeOffsetConverter,
+  stringToNumberConverter,
+} from "@odata2ts/converter-v2-to-v4";
 
 import { timeToMsDurationConverter } from "./TimeToMsDurationConverter";
 
@@ -10,6 +14,7 @@ const pkg: ConverterPackage = {
   id: "UI5",
   converters: [
     stringToNumberConverter,
+    bigNumberNoopConverter,
     dateTimeToDateTimeOffsetConverter,
     dateTimeOffsetToDateConverter,
     timeToMsDurationConverter,
@@ -19,6 +24,7 @@ const pkg: ConverterPackage = {
 export default pkg;
 export {
   stringToNumberConverter,
+  bigNumberNoopConverter,
   dateTimeToDateTimeOffsetConverter,
   dateTimeOffsetToDateConverter,
   timeToMsDurationConverter,

--- a/packages/converter-ui5-v2/test/package.test.ts
+++ b/packages/converter-ui5-v2/test/package.test.ts
@@ -5,6 +5,7 @@ import * as pkg from "../src";
 describe("UI5 Converter Package Tests", function () {
   const usedConverters = [
     "stringToNumberConverter",
+    "bigNumberNoopConverter",
     "dateTimeToDateTimeOffsetConverter",
     "dateTimeOffsetToDateConverter",
     "timeToMsDurationConverter",

--- a/packages/converter-v2-to-v4/src/BigNumberNoopConverter.ts
+++ b/packages/converter-v2-to-v4/src/BigNumberNoopConverter.ts
@@ -1,0 +1,16 @@
+import { ParamValueModel, ValueConverter } from "@odata2ts/converter-api";
+import { ODataTypesV2 } from "@odata2ts/odata-core";
+
+export const bigNumberNoopConverter: ValueConverter<string, string> = {
+  id: "bigNumberNoopConverter",
+  from: [ODataTypesV2.Int64, ODataTypesV2.Decimal],
+  to: "string",
+
+  convertFrom: function (value: ParamValueModel<string>): ParamValueModel<string> {
+    return value;
+  },
+
+  convertTo: function (value: ParamValueModel<string>): ParamValueModel<string> {
+    return value;
+  },
+};

--- a/packages/converter-v2-to-v4/src/StringToNumberConverter.ts
+++ b/packages/converter-v2-to-v4/src/StringToNumberConverter.ts
@@ -16,6 +16,8 @@ export const stringToNumberConverter: ValueConverter<string, number> = {
     ODataTypesV2.SByte,
     ODataTypesV2.Single,
     ODataTypesV2.Double,
+    ODataTypesV2.Int64,
+    ODataTypesV2.Decimal,
   ],
   to: "number",
 

--- a/packages/converter-v2-to-v4/src/index.ts
+++ b/packages/converter-v2-to-v4/src/index.ts
@@ -1,5 +1,6 @@
 import { ConverterPackage } from "@odata2ts/converter-api";
 
+import { bigNumberNoopConverter } from "./BigNumberNoopConverter";
 import { dateTimeToDateTimeOffsetConverter } from "./DateTimeToDateTimeOffsetConverter";
 import { stringToNumberConverter } from "./StringToNumberConverter";
 import { timeToDurationConverter } from "./TimeToDurationConverter";
@@ -14,6 +15,7 @@ export default pkg;
 export {
   dateTimeToDateTimeOffsetConverter,
   stringToNumberConverter,
+  bigNumberNoopConverter,
   timeToDurationConverter,
   timeToTimeOfDayConverter,
 };

--- a/packages/converter-v2-to-v4/test/BigNumberNoopConverter.test.ts
+++ b/packages/converter-v2-to-v4/test/BigNumberNoopConverter.test.ts
@@ -1,0 +1,28 @@
+import { ODataTypesV2 } from "@odata2ts/odata-core";
+
+import { bigNumberNoopConverter } from "../lib";
+
+describe("BigNumberNoopConverter Test", () => {
+  const TO_TEST = bigNumberNoopConverter;
+
+  test("base attributes", () => {
+    expect(TO_TEST.id).toBe("bigNumberNoopConverter");
+    expect(TO_TEST.from).toStrictEqual([ODataTypesV2.Int64, ODataTypesV2.Decimal]);
+    expect(TO_TEST.to).toBe("string");
+  });
+
+  test("conversion", () => {
+    expect(TO_TEST.convertFrom("12.59")).toBe("12.59");
+    expect(TO_TEST.convertTo("12.59")).toBe("12.59");
+    expect(TO_TEST.convertFrom("-46")).toBe("-46");
+    expect(TO_TEST.convertTo("-46")).toBe("-46");
+  });
+
+  test("null, undefined and invalid input", () => {
+    expect(TO_TEST.convertFrom(null)).toBeNull();
+    expect(TO_TEST.convertFrom(undefined)).toBeUndefined();
+
+    expect(TO_TEST.convertTo(null)).toBeNull();
+    expect(TO_TEST.convertTo(undefined)).toBeUndefined();
+  });
+});

--- a/packages/converter-v2-to-v4/test/BigNumberNoopConverter.test.ts
+++ b/packages/converter-v2-to-v4/test/BigNumberNoopConverter.test.ts
@@ -1,6 +1,6 @@
 import { ODataTypesV2 } from "@odata2ts/odata-core";
 
-import { bigNumberNoopConverter } from "../lib";
+import { bigNumberNoopConverter } from "../src";
 
 describe("BigNumberNoopConverter Test", () => {
   const TO_TEST = bigNumberNoopConverter;
@@ -18,11 +18,10 @@ describe("BigNumberNoopConverter Test", () => {
     expect(TO_TEST.convertTo("-46")).toBe("-46");
   });
 
-  test("null, undefined and invalid input", () => {
+  test("null, undefined", () => {
     expect(TO_TEST.convertFrom(null)).toBeNull();
-    expect(TO_TEST.convertFrom(undefined)).toBeUndefined();
-
     expect(TO_TEST.convertTo(null)).toBeNull();
+    expect(TO_TEST.convertFrom(undefined)).toBeUndefined();
     expect(TO_TEST.convertTo(undefined)).toBeUndefined();
   });
 });

--- a/packages/converter-v2-to-v4/test/StringToNumberConverter.test.ts
+++ b/packages/converter-v2-to-v4/test/StringToNumberConverter.test.ts
@@ -12,8 +12,8 @@ describe("StringToNumberConverter Test", () => {
       ODataTypesV2.SByte,
       ODataTypesV2.Single,
       ODataTypesV2.Double,
-      // ODataTypesV2.Int64,
-      // ODataTypesV2.Decimal,
+      ODataTypesV2.Int64,
+      ODataTypesV2.Decimal,
     ]);
     expect(TO_TEST.to).toBe("number");
   });


### PR DESCRIPTION
number conversion of Edm.Int64 & Edm.Decimal by default; introduce bigNumberNoopConverter to prevent exactly that conversion