### PR TITLE
refactor(v2-to-v4): convert Ed.Time to Edm.TimeOfDay by default instead of Edm.Duration

### DIFF
--- a/packages/converter-runtime/test/loadConverter.test.ts
+++ b/packages/converter-runtime/test/loadConverter.test.ts
@@ -28,11 +28,11 @@ describe("LoadConverters Test", () => {
 
     const timeType = result?.get(ODataTypesV2.Time);
     expect(timeType?.from).toBe("Edm.Time");
-    expect(timeType?.to).toBe(ODataTypesV4.Duration);
+    expect(timeType?.to).toBe(ODataTypesV4.TimeOfDay);
     expect(timeType?.converters).toStrictEqual([
       {
         package: V2_TO_V4_PKG,
-        converterId: "timeToDurationConverter",
+        converterId: "timeToTimeOfDayConverter",
       },
     ]);
   });

--- a/packages/converter-v2-to-v4/src/index.ts
+++ b/packages/converter-v2-to-v4/src/index.ts
@@ -8,14 +8,14 @@ import { timeToTimeOfDayConverter } from "./TimeToTimeOfDayConverter";
 
 const pkg: ConverterPackage = {
   id: "V2ToV4",
-  converters: [dateTimeToDateTimeOffsetConverter, stringToNumberConverter, timeToDurationConverter],
+  converters: [dateTimeToDateTimeOffsetConverter, stringToNumberConverter, timeToTimeOfDayConverter],
 };
 
 export default pkg;
 export {
   dateTimeToDateTimeOffsetConverter,
   stringToNumberConverter,
-  bigNumberNoopConverter,
-  timeToDurationConverter,
   timeToTimeOfDayConverter,
+  timeToDurationConverter,
+  bigNumberNoopConverter,
 };


### PR DESCRIPTION
BREAKING CHANGE: different converter used by default