### PR TITLE
feat(converter-runtime): support fixing converters

### DIFF
--- a/examples/test-converters/package.json
+++ b/examples/test-converters/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@odata2ts/test-converters",
+  "name": "@odata2ts/converter-example",
   "version": "0.3.1",
   "private": true,
   "repository": "git@github.com:odata2ts/converter.git",

--- a/examples/test-converters/src/ExampleOfFixingDataType.ts
+++ b/examples/test-converters/src/ExampleOfFixingDataType.ts
@@ -1,0 +1,15 @@
+import { ParamValueModel, ValueConverter } from "@odata2ts/converter-api";
+
+export const exampleOfFixingConverter: ValueConverter<boolean, boolean> = {
+  id: "exampleOfFixingConverter",
+  from: "Edm.Boolean",
+  to: "Edm.Boolean",
+  convertFrom: (value: ParamValueModel<boolean>): ParamValueModel<boolean> => {
+    // here you would do something to fix the type
+    return value;
+  },
+  convertTo: (value: ParamValueModel<boolean>): ParamValueModel<boolean> => {
+    // and here you would do something to unfix the type
+    return value;
+  },
+};

--- a/examples/test-converters/src/index.ts
+++ b/examples/test-converters/src/index.ts
@@ -3,13 +3,20 @@ import { booleanToNumberConverter } from "./BooleanToNumberConverter";
 import { converterWithWrongId } from "./ConverterWithWrongId";
 import { numberToStringConverter } from "./NumberToStringConverter";
 import { stringToPrefixModelConverter } from "./StringToPrefixModelConverter";
+import { exampleOfFixingConverter } from "./ExampleOfFixingDataType";
 
 const pkg: ConverterPackage = {
   id: "test-converters",
-  converters: [booleanToNumberConverter, numberToStringConverter, stringToPrefixModelConverter],
+  converters: [exampleOfFixingConverter, booleanToNumberConverter, numberToStringConverter, stringToPrefixModelConverter]
 };
 
 export default pkg;
 export * from "./FixedDateConverter";
 export * from "./StringToPrefixModelConverter";
-export { booleanToNumberConverter, stringToPrefixModelConverter, numberToStringConverter, converterWithWrongId };
+export {
+  exampleOfFixingConverter,
+  booleanToNumberConverter,
+  stringToPrefixModelConverter,
+  numberToStringConverter,
+  converterWithWrongId
+};

--- a/packages/converter-runtime/package.json
+++ b/packages/converter-runtime/package.json
@@ -35,6 +35,7 @@
     "@odata2ts/converter-api": "^0.2.1"
   },
   "devDependencies": {
+    "@odata2ts/converter-example": "^0.3.1",
     "@odata2ts/converter-luxon": "^0.2.2",
     "@odata2ts/converter-v2-to-v4": "^0.5.2",
     "@types/node": "^17.0.23",

--- a/packages/converter-runtime/test/ChainedCoverter.test.ts
+++ b/packages/converter-runtime/test/ChainedCoverter.test.ts
@@ -2,7 +2,7 @@ import {
   booleanToNumberConverter,
   numberToStringConverter,
   stringToPrefixModelConverter,
-} from "@odata2ts/test-converters";
+} from "@odata2ts/converter-example";
 import { describe, expect, test } from "vitest";
 import { ChainedConverter, createChain } from "../src";
 

--- a/packages/converter-runtime/test/loadConverter.test.ts
+++ b/packages/converter-runtime/test/loadConverter.test.ts
@@ -5,10 +5,11 @@ import { getPropTypeAndModule, loadConverters } from "../src";
 
 describe("LoadConverters Test", () => {
   const V2_TO_V4_PKG = "@odata2ts/converter-v2-to-v4";
-  const LUXON_PKG = "@odata2ts/converter-luxon";
-
   // time, dateTime, byte, sByte, single, double, int64, decimal
   const V2_TO_V4_CONVERTERS_SIZE = 8;
+  const LUXON_PKG = "@odata2ts/converter-luxon";
+  const TEST_CONV_PKG = "@odata2ts/converter-example";
+
 
   test("no converters", async () => {
     const result = await loadConverters(ODataVersions.V4, undefined);
@@ -156,4 +157,31 @@ describe("LoadConverters Test", () => {
     expect(getPropTypeAndModule("aba.ts")).toStrictEqual(["ts", "aba"]);
     expect(getPropTypeAndModule("aba.js.Type")).toStrictEqual(["Type", "aba.js"]);
   });
+
+  test("with fixing converter in between", async () => {
+    const result = await loadConverters(ODataVersions.V4, [TEST_CONV_PKG]);
+
+    const booleanChain = result?.get(ODataTypesV4.Boolean);
+    expect(booleanChain).toStrictEqual({
+      from: ODataTypesV4.Boolean,
+      to: "string",
+      toModule: undefined,
+      converters: [
+        {
+          package: TEST_CONV_PKG,
+          converterId: "exampleOfFixingConverter",
+        },
+        {
+          package: TEST_CONV_PKG,
+          converterId: "booleanToNumberConverter",
+        },
+        {
+          package: TEST_CONV_PKG,
+          converterId: "numberToStringConverter",
+        },
+      ],
+    } as ValueConverterChain);
+  });
+
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,6 +2038,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@odata2ts/converter-example@^0.3.1, @odata2ts/converter-example@workspace:examples/test-converters":
+  version: 0.0.0-use.local
+  resolution: "@odata2ts/converter-example@workspace:examples/test-converters"
+  dependencies:
+    "@odata2ts/converter-api": ^0.2.1
+    rimraf: ^3.0.2
+    typescript: 4.6.3
+  languageName: unknown
+  linkType: soft
+
 "@odata2ts/converter-luxon@^0.2.2, @odata2ts/converter-luxon@workspace:packages/converter-luxon":
   version: 0.0.0-use.local
   resolution: "@odata2ts/converter-luxon@workspace:packages/converter-luxon"
@@ -2077,6 +2087,7 @@ __metadata:
   resolution: "@odata2ts/converter-runtime@workspace:packages/converter-runtime"
   dependencies:
     "@odata2ts/converter-api": ^0.2.1
+    "@odata2ts/converter-example": ^0.3.1
     "@odata2ts/converter-luxon": ^0.2.2
     "@odata2ts/converter-v2-to-v4": ^0.5.2
     "@types/node": ^17.0.23
@@ -2205,16 +2216,6 @@ __metadata:
   checksum: d86d44949cb72b8cd0682a4389615aa564bbe21387864bf5bae98f2a83ca65d4fa608aa25ed9651d765762a41c602d329d23c12ca0390e632949b25903b0f931
   languageName: node
   linkType: hard
-
-"@odata2ts/test-converters@workspace:examples/test-converters":
-  version: 0.0.0-use.local
-  resolution: "@odata2ts/test-converters@workspace:examples/test-converters"
-  dependencies:
-    "@odata2ts/converter-api": ^0.2.1
-    rimraf: ^3.0.2
-    typescript: 4.6.3
-  languageName: unknown
-  linkType: soft
 
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0


### PR DESCRIPTION
Converters with same source and target type (because you're just fixing a data type), are now supported to be part of the converter chain.