### PR TITLE
fix: load prettier.config.js correctly under CommonJS

### DIFF
--- a/examples/test-converters/src/index.ts
+++ b/examples/test-converters/src/index.ts
@@ -1,13 +1,18 @@
 import { ConverterPackage } from "@odata2ts/converter-api";
 import { booleanToNumberConverter } from "./BooleanToNumberConverter";
 import { converterWithWrongId } from "./ConverterWithWrongId";
+import { exampleOfFixingConverter } from "./ExampleOfFixingDataType";
 import { numberToStringConverter } from "./NumberToStringConverter";
 import { stringToPrefixModelConverter } from "./StringToPrefixModelConverter";
-import { exampleOfFixingConverter } from "./ExampleOfFixingDataType";
 
 const pkg: ConverterPackage = {
   id: "test-converters",
-  converters: [exampleOfFixingConverter, booleanToNumberConverter, numberToStringConverter, stringToPrefixModelConverter]
+  converters: [
+    exampleOfFixingConverter,
+    booleanToNumberConverter,
+    numberToStringConverter,
+    stringToPrefixModelConverter,
+  ],
 };
 
 export default pkg;
@@ -18,5 +23,5 @@ export {
   booleanToNumberConverter,
   stringToPrefixModelConverter,
   numberToStringConverter,
-  converterWithWrongId
+  converterWithWrongId,
 };

--- a/packages/converter-api/src/index.ts
+++ b/packages/converter-api/src/index.ts
@@ -35,7 +35,7 @@ export interface ValueConverterType {
 }
 
 export interface ConverterOptions {
-  urlConversion?: boolean
+  urlConversion?: boolean;
 }
 
 export interface ValueConverter<OriginalType, ConvertedType> extends ValueConverterType {
@@ -66,7 +66,9 @@ export type ParamValueModel<Type> = Type | null | undefined;
  */
 export interface IdentityConverter<OriginalType> extends ValueConverter<OriginalType, OriginalType> {}
 
-export interface ChainableValueConverter<OriginalType, ConvertedType>
-  extends ValueConverter<OriginalType, ConvertedType> {
+export interface ChainableValueConverter<OriginalType, ConvertedType> extends ValueConverter<
+  OriginalType,
+  ConvertedType
+> {
   chain<T>(converterToChain: ValueConverter<ConvertedType, T>): ChainableValueConverter<OriginalType, T>;
 }

--- a/packages/converter-big-number/test/BigNumberConverter.test.ts
+++ b/packages/converter-big-number/test/BigNumberConverter.test.ts
@@ -39,6 +39,4 @@ describe("BigNumberConverter Test", () => {
     // @ts-expect-error
     expect(TO_TEST.convertTo("INVALID!!!")).toBe("INVALID!!!");
   });
-
-
 });

--- a/packages/converter-runtime/src/ChainedConverter.ts
+++ b/packages/converter-runtime/src/ChainedConverter.ts
@@ -1,4 +1,4 @@
-import {ChainableValueConverter, ConverterOptions, ParamValueModel, ValueConverter} from "@odata2ts/converter-api";
+import { ChainableValueConverter, ConverterOptions, ParamValueModel, ValueConverter } from "@odata2ts/converter-api";
 
 export class ChainedConverter<FromType, IntermediateType, ToType> implements ChainableValueConverter<FromType, ToType> {
   public readonly id = "ChainedConverter";

--- a/packages/converter-runtime/src/loadConverters.ts
+++ b/packages/converter-runtime/src/loadConverters.ts
@@ -4,10 +4,10 @@ import {
   RuntimeConverterPackage,
   TypeConverterConfig,
   ValueConverterChain,
-  ValueConverterImport
+  ValueConverterImport,
 } from "./ConverterModels";
 
-type MappedConverter = ValueConverterType & { package: string; toModule?: string }
+type MappedConverter = ValueConverterType & { package: string; toModule?: string };
 // we use an array of converters because of converters which fix stuff, mapping from and to the identical type
 type MappedConverters = Map<string, Array<MappedConverter>>;
 
@@ -85,19 +85,18 @@ function mapConvertersBySource(converterPkgs: Array<RuntimeConverterPackage>): M
         const [fromType] = getPropTypeAndModule(from);
         const [toType, toModule] = getPropTypeAndModule(converter.to);
 
-        const result:MappedConverter = {
+        const result: MappedConverter = {
           package: converterPkg.package,
           id: converter.id,
           from: fromType,
           to: toType,
           toModule,
-        }
+        };
 
         const prev = collector.get(from);
-        if (prev?.length && prev[prev.length-1].to === fromType) {
+        if (prev?.length && prev[prev.length - 1].to === fromType) {
           prev.push(result);
-        }
-        else {
+        } else {
           collector.set(from, [result]);
         }
       }
@@ -153,18 +152,21 @@ function chainConverters(converters: MappedConverters, dataType: string): ValueC
     return undefined;
   }
 
-  const finalConv = conv[conv.length-1];
+  const finalConv = conv[conv.length - 1];
   const usedConverters: Array<ValueConverterImport> = [];
   if (conv.length > 1) {
-    usedConverters.push(...conv.slice(0, conv.length -1).map(c => ({
-        package: c.package, converterId: c.id
-    })))
+    usedConverters.push(
+      ...conv.slice(0, conv.length - 1).map((c) => ({
+        package: c.package,
+        converterId: c.id,
+      })),
+    );
   }
 
   usedConverters.push({
     package: finalConv.package,
-    converterId: finalConv.id
-  })
+    converterId: finalConv.id,
+  });
 
   const chainedConv = chainConverters(converters, finalConv.to);
   if (chainedConv?.converters) {

--- a/packages/converter-runtime/test/loadConverter.test.ts
+++ b/packages/converter-runtime/test/loadConverter.test.ts
@@ -10,7 +10,6 @@ describe("LoadConverters Test", () => {
   const LUXON_PKG = "@odata2ts/converter-luxon";
   const TEST_CONV_PKG = "@odata2ts/converter-example";
 
-
   test("no converters", async () => {
     const result = await loadConverters(ODataVersions.V4, undefined);
     expect(result).toBeUndefined();
@@ -182,6 +181,4 @@ describe("LoadConverters Test", () => {
       ],
     } as ValueConverterChain);
   });
-
-
 });

--- a/packages/converter-v2-to-v4/src/DateTimeToDateTimeOffsetConverter.ts
+++ b/packages/converter-v2-to-v4/src/DateTimeToDateTimeOffsetConverter.ts
@@ -1,4 +1,4 @@
-import {ConverterOptions, ParamValueModel, ValueConverter} from "@odata2ts/converter-api";
+import { ConverterOptions, ParamValueModel, ValueConverter } from "@odata2ts/converter-api";
 import { ODataTypesV2, ODataTypesV4 } from "@odata2ts/odata-core";
 
 function padZerosLeft(input: number) {
@@ -18,7 +18,7 @@ function formatDateTimeV2(iso8601: string, offset?: string) {
 // offset in minutes might be specified as suffix of the timestamp,e.g. "+90"
 const DATE_TIME_V2_REGEXP = /\/Date\(([+-]?\d+)(([+-])(\d+))?\)\//;
 const ISO_OFFSET_REGEXP = /([+-])(\d{2}):(\d{2})/;
-const ISO_DATETIME_REGEXP = /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(([+-]\d\d:\d\d)|Z)?$/i
+const ISO_DATETIME_REGEXP = /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(([+-]\d\d:\d\d)|Z)?$/i;
 
 /**
  * Converts Edm.DateTime, which is a very special construct, to Edm.DateTimeOffset, which is the typical

--- a/packages/converter-v2-to-v4/test/DateTimeToDateTimeOffsetConverter.test.ts
+++ b/packages/converter-v2-to-v4/test/DateTimeToDateTimeOffsetConverter.test.ts
@@ -1,6 +1,6 @@
-import {ODataTypesV2, ODataTypesV4} from "@odata2ts/odata-core";
-import {describe, expect, test} from "vitest";
-import {dateTimeToDateTimeOffsetConverter} from "../src";
+import { ODataTypesV2, ODataTypesV4 } from "@odata2ts/odata-core";
+import { describe, expect, test } from "vitest";
+import { dateTimeToDateTimeOffsetConverter } from "../src";
 
 describe("V2DateTimeToDateTimeOffset Test", () => {
   const TIMESTAMP = 1672531199000;

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: ["@prettier/plugin-xml", "prettier-plugin-packagejson", "@ianvs/prettier-plugin-sort-imports"],
   printWidth: 120,
   tabWidth: 2,


### PR DESCRIPTION
- prettier.config.js used `export default` while package.json declares `"type": "commonjs"`, causing prettier to fail with a syntax error instead of ever applying formatting
- switched to `module.exports`
- applied the formatting fixes this newly surfaced across 8 files (import brace spacing, missing semicolons/trailing commas, one wrapped array literal) — cosmetic only, no logic changes