### PR TITLE
fix: align NaN handling and bignumber.js dependency declaration of the big number converters

### DIFF
--- a/packages/converter-big-number/package.json
+++ b/packages/converter-big-number/package.json
@@ -30,11 +30,13 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@odata2ts/converter-api": "^0.2.6",
-    "bignumber.js": "^11.1.5"
+    "@odata2ts/converter-api": "^0.2.6"
   },
   "devDependencies": {
     "bignumber.js": "^11.1.5"
+  },
+  "peerDependencies": {
+    "bignumber.js": ">1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/converter-big-number/test/BigNumberConverter.test.ts
+++ b/packages/converter-big-number/test/BigNumberConverter.test.ts
@@ -31,6 +31,12 @@ describe("BigNumberConverter Test", () => {
 
   test("convertFrom with invalid value", () => {
     expect(() => TO_TEST.convertFrom("hello")).toThrow("[BigNumber Error] Invalid argument: hello");
+    expect(() => TO_TEST.convertFrom("")).toThrow("[BigNumber Error] Invalid argument: ");
+  });
+
+  test("convertFrom with NaN", () => {
+    // bignumber.js accepts the literal string "NaN", the converter must not let it pass
+    expect(() => TO_TEST.convertFrom("NaN")).toThrow("[BigNumber Error] Invalid argument: NaN");
   });
 
   test("convertTo: no conversion for string value", () => {

--- a/packages/converter-decimal/src/DecimalConverter.ts
+++ b/packages/converter-decimal/src/DecimalConverter.ts
@@ -13,7 +13,12 @@ export const decimalConverter: ValueConverter<string, Decimal> & {
       return value;
     }
 
-    return new Decimal(value);
+    // decimal.js itself throws for unparsable input, but accepts the literal string "NaN"
+    const result = new Decimal(value);
+    if (result.isNaN()) {
+      throw new Error("[DecimalError] Invalid argument: " + value);
+    }
+    return result;
   },
 
   convertTo: function (value: ParamValueModel<Decimal | string>): ParamValueModel<string> {

--- a/packages/converter-decimal/test/DecimalConverter.test.ts
+++ b/packages/converter-decimal/test/DecimalConverter.test.ts
@@ -36,5 +36,11 @@ describe("BigNumberConverter Test", () => {
 
   test("convertFrom with invalid value", () => {
     expect(() => TO_TEST.convertFrom("hello")).toThrow("[DecimalError] Invalid argument: hello");
+    expect(() => TO_TEST.convertFrom("")).toThrow("[DecimalError] Invalid argument: ");
+  });
+
+  test("convertFrom with NaN", () => {
+    // decimal.js accepts the literal string "NaN", the converter must not let it pass
+    expect(() => TO_TEST.convertFrom("NaN")).toThrow("[DecimalError] Invalid argument: NaN");
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,6 +1083,8 @@ __metadata:
   dependencies:
     "@odata2ts/converter-api": "npm:^0.2.6"
     bignumber.js: "npm:^11.1.5"
+  peerDependencies:
+    bignumber.js: ">1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- `decimalConverter` now rejects the literal string `"NaN"` instead of silently returning a NaN-valued `Decimal` — both decimal.js and bignumber.js accept `"NaN"` as valid constructor input, but `bigNumberConverter` has always filtered it out. Both converters now behave identically for every input.
- `converter-big-number` declares `bignumber.js` as a `peerDependency` (`">1"`) plus `devDependency`, mirroring `converter-decimal`, instead of a regular dependency pinned to `^11.1.5` that was additionally duplicated as a `devDependency`. As a regular dependency a consumer on a different major ends up with two copies of bignumber.js in the tree, breaking `instanceof BigNumber` for the converter's public `BigNumber.Instance` type; the README has always asked users to install bignumber.js themselves.
- Added a `convertFrom with NaN` test to both packages (the branch was previously untested in `converter-big-number`) and extended the invalid-value tests to cover the empty string.