### PR TITLE
fix(converter-runtime): report actionable errors when loading converters

### DIFF
--- a/packages/converter-runtime/src/loadConverters.ts
+++ b/packages/converter-runtime/src/loadConverters.ts
@@ -22,9 +22,33 @@ function isConverterPackage(candidate: unknown): candidate is ConverterPackage {
   return (
     !!candidate &&
     typeof (candidate as ConverterPackage).id === "string" &&
-    typeof (candidate as ConverterPackage).converters?.length === "number"
+    Array.isArray((candidate as ConverterPackage).converters)
   );
 }
+
+/**
+ * Checks the meta information every converter must provide, no matter how it was loaded.
+ * Without this the first malformed converter surfaces as a TypeError deep within the mapping step,
+ * naming neither the package nor the converter it came from.
+ */
+function isValueConverter(candidate: unknown): candidate is ValueConverterType {
+  if (!candidate || typeof candidate !== "object") {
+    return false;
+  }
+  const { id, from, to } = candidate as ValueConverterType;
+  const validFrom =
+    typeof from === "string"
+      ? !!from
+      : Array.isArray(from) && !!from.length && from.every((f) => !!f && typeof f === "string");
+  return typeof id === "string" && !!id && validFrom && typeof to === "string" && !!to;
+}
+
+function describeConverter(candidate: unknown) {
+  const id = (candidate as ValueConverterType | undefined)?.id;
+  return typeof id === "string" && id ? `Converter "${id}"` : "Converter";
+}
+
+const CONVERTER_CONTRACT_HINT = `requires a non-empty string "id", a non-empty string or string array "from" and a non-empty string "to"`;
 
 async function doLoad(converters: Array<TypeConverterConfig>): Promise<Array<RuntimeConverterPackage>> {
   return Promise.all(
@@ -32,7 +56,7 @@ async function doLoad(converters: Array<TypeConverterConfig>): Promise<Array<Run
       // dynamic import => works only for Node.js
       return import(conv.module)
         .catch((e) => {
-          throw new Error(`Failed to load module "${conv.module}"!`, e);
+          throw new Error(`Failed to load module "${conv.module}"!`, { cause: e });
         })
         .then((module) => {
           let converters: Array<ValueConverterType>;
@@ -44,6 +68,11 @@ async function doLoad(converters: Array<TypeConverterConfig>): Promise<Array<Run
               const loaded = module[convId];
               if (!loaded) {
                 throw new Error(`Converter with id "${convId}" doesn't exist in module "${conv.module}"!`);
+              }
+              if (!isValueConverter(loaded)) {
+                throw new Error(
+                  `Export "${convId}" of module "${conv.module}" is not a valid converter: ${CONVERTER_CONTRACT_HINT}!`,
+                );
               }
               converters.push(loaded);
             }
@@ -60,6 +89,13 @@ async function doLoad(converters: Array<TypeConverterConfig>): Promise<Array<Run
               throw new Error(`Default export of loaded module "${conv.module}" doesn't conform to specification!`);
             }
             converters = candidate.converters;
+
+            const invalidIndex = converters.findIndex((converter) => !isValueConverter(converter));
+            if (invalidIndex >= 0) {
+              throw new Error(
+                `${describeConverter(converters[invalidIndex])} at index ${invalidIndex} of module "${conv.module}" is not a valid converter: ${CONVERTER_CONTRACT_HINT}!`,
+              );
+            }
           }
 
           return {
@@ -145,11 +181,34 @@ export async function loadConverters(
   }, new Map() as MappedConverterChains);
 }
 
+/**
+ * Builds the message for a converter chain that leads back to a type it already visited.
+ * Such a chain can only be produced by combining packages, so the involved ones are named.
+ */
+function createCycleError(converters: MappedConverters, dataType: string, visited: Array<string>) {
+  const cycle = [...visited.slice(visited.indexOf(dataType)), dataType];
+  const packages = [...new Set(cycle.flatMap((type) => converters.get(type)?.map((c) => c.package) ?? []))];
+
+  return new Error(
+    `Cyclic converter chain detected: ${cycle.join(" -> ")}! Involved package(s): ${packages
+      .map((p) => `"${p}"`)
+      .join(", ")}.`,
+  );
+}
+
 // Recursive function to find chainable converters and chain them
-function chainConverters(converters: MappedConverters, dataType: string): ValueConverterChain | undefined {
+function chainConverters(
+  converters: MappedConverters,
+  dataType: string,
+  visited: Array<string> = [],
+): ValueConverterChain | undefined {
   const conv = converters.get(dataType);
   if (!conv?.length) {
     return undefined;
+  }
+
+  if (visited.includes(dataType)) {
+    throw createCycleError(converters, dataType, visited);
   }
 
   const finalConv = conv[conv.length - 1];
@@ -168,7 +227,7 @@ function chainConverters(converters: MappedConverters, dataType: string): ValueC
     converterId: finalConv.id,
   });
 
-  const chainedConv = chainConverters(converters, finalConv.to);
+  const chainedConv = chainConverters(converters, finalConv.to, [...visited, dataType]);
   if (chainedConv?.converters) {
     usedConverters.push(...chainedConv.converters);
   }

--- a/packages/converter-runtime/test/fixture/cyclic-a.mjs
+++ b/packages/converter-runtime/test/fixture/cyclic-a.mjs
@@ -1,0 +1,5 @@
+// Maps Edm.String onto an intermediate type ...
+export default {
+  id: "CyclicA",
+  converters: [{ id: "toIntermediateConverter", from: "Edm.String", to: "IntermediateType" }],
+};

--- a/packages/converter-runtime/test/fixture/cyclic-b.mjs
+++ b/packages/converter-runtime/test/fixture/cyclic-b.mjs
@@ -1,0 +1,5 @@
+// ... which this one maps straight back, closing the loop.
+export default {
+  id: "CyclicB",
+  converters: [{ id: "backToStringConverter", from: "IntermediateType", to: "Edm.String" }],
+};

--- a/packages/converter-runtime/test/fixture/invalid-converter.mjs
+++ b/packages/converter-runtime/test/fixture/invalid-converter.mjs
@@ -1,0 +1,11 @@
+export const validConverter = { id: "validConverter", from: "Edm.String", to: "number" };
+
+// Exports that are reachable via "use", but are no converters at all.
+export const notAConverter = "1.0.0";
+export const halfConverter = { id: "halfConverter", from: "Edm.String" };
+
+// The package itself is well formed, the second converter within it is not: "to" is missing.
+export default {
+  id: "InvalidConverter",
+  converters: [validConverter, { id: "brokenConverter", from: "Edm.Boolean" }],
+};

--- a/packages/converter-runtime/test/fixture/invalid-package.mjs
+++ b/packages/converter-runtime/test/fixture/invalid-package.mjs
@@ -1,0 +1,2 @@
+// "converters" is a string: it has a numeric "length" and used to pass the package check.
+export default { id: "InvalidPackage", converters: "abc" };

--- a/packages/converter-runtime/test/loadConverter.test.ts
+++ b/packages/converter-runtime/test/loadConverter.test.ts
@@ -1,7 +1,10 @@
+import { fileURLToPath } from "node:url";
 import { ValueConverterChain } from "@odata2ts/converter-runtime";
 import { ODataTypesV2, ODataTypesV4, ODataVersions } from "@odata2ts/odata-core";
 import { describe, expect, test } from "vitest";
 import { getPropTypeAndModule, loadConverters } from "../src";
+
+const fixture = (name: string) => fileURLToPath(new URL(`./fixture/${name}`, import.meta.url));
 
 describe("LoadConverters Test", () => {
   const V2_TO_V4_PKG = "@odata2ts/converter-v2-to-v4";
@@ -44,6 +47,14 @@ describe("LoadConverters Test", () => {
     await expect(loadConverters(ODataVersions.V2, [fakeModule])).rejects.toMatchObject(expectedError);
     await expect(loadConverters(ODataVersions.V2, [V2_TO_V4_PKG, fakeModule])).rejects.toMatchObject(expectedError);
     await expect(loadConverters(ODataVersions.V2, [fakeModule, V2_TO_V4_PKG])).rejects.toMatchObject(expectedError);
+  });
+
+  test("failure to load keeps the underlying reason as cause", async () => {
+    // without it a missing peer dependency is indistinguishable from a typo in the package name
+    const error = await loadConverters(ODataVersions.V2, ["xxxxNotExistentxxxx"]).catch((e) => e);
+
+    expect(error.cause).toBeDefined();
+    expect(String(error.cause)).toContain("xxxxNotExistentxxxx");
   });
 
   test("load installed converters with no application", async () => {
@@ -148,6 +159,49 @@ describe("LoadConverters Test", () => {
         },
       ],
     } as ValueConverterChain);
+  });
+
+  test("cyclic converter chain", async () => {
+    // combining these two packages closes a loop: Edm.String -> IntermediateType -> Edm.String
+    const promise = loadConverters(ODataVersions.V4, [fixture("cyclic-a.mjs"), fixture("cyclic-b.mjs")]);
+
+    await expect(promise).rejects.toThrow(
+      "Cyclic converter chain detected: Edm.String -> IntermediateType -> Edm.String!",
+    );
+    // the packages are what the user has to act on, so they must be named
+    await expect(promise).rejects.toThrow("cyclic-a.mjs");
+    await expect(promise).rejects.toThrow("cyclic-b.mjs");
+  });
+
+  test("package whose converter list is no array", async () => {
+    await expect(loadConverters(ODataVersions.V4, [fixture("invalid-package.mjs")])).rejects.toThrow(
+      `doesn't conform to specification!`,
+    );
+  });
+
+  test("package containing an invalid converter", async () => {
+    await expect(loadConverters(ODataVersions.V4, [fixture("invalid-converter.mjs")])).rejects.toThrow(
+      /Converter "brokenConverter" at index 1 of module ".*invalid-converter\.mjs" is not a valid converter/,
+    );
+  });
+
+  test("named import which is no converter", async () => {
+    const module = fixture("invalid-converter.mjs");
+
+    await expect(loadConverters(ODataVersions.V4, [{ module, use: ["notAConverter"] }])).rejects.toThrow(
+      /Export "notAConverter" of module ".*" is not a valid converter/,
+    );
+    await expect(loadConverters(ODataVersions.V4, [{ module, use: ["halfConverter"] }])).rejects.toThrow(
+      /Export "halfConverter" of module ".*" is not a valid converter/,
+    );
+  });
+
+  test("valid named import from the same module still works", async () => {
+    const result = await loadConverters(ODataVersions.V4, [
+      { module: fixture("invalid-converter.mjs"), use: ["validConverter"] },
+    ]);
+
+    expect(result?.get(ODataTypesV4.String)).toMatchObject({ from: ODataTypesV4.String, to: "number" });
   });
 
   test("getPropTypeAndModule", () => {


### PR DESCRIPTION
- A module that fails to import passed its underlying reason as the second `Error` argument, which is an options object rather than a cause, so the reason was dropped — a missing peer dependency looked exactly like a typo in the package name. It is now passed as `{ cause }`.
- A converter chain leading back to a type it already visited recursed until the stack blew (`RangeError: Maximum call stack size exceeded`). Such a chain is usually produced by combining two packages that are each fine on their own, so the error now names the cycle (`Edm.String -> IntermediateType -> Edm.String`) and the packages involved.
- Converters themselves were never validated: `isConverterPackage` only checked that `converters` had a numeric `length`, which a string satisfies, and the `use` path checked nothing beyond the export being truthy. Every malformed converter surfaced as `TypeError: froms is not iterable` from deep within the mapping step. Both load paths now check the `id`/`from`/`to` contract and name the offending package and converter.
- Added tests for all four cases, backed by fixture modules under `test/fixture/`.