### PR TITLE
build: declare tool binaries in every workspace that invokes them

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,6 +21,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Install packages
         run: yarn --immutable
+      - name: Check dependency consistency
+        run: yarn constraints
       - name: Build
         run: yarn build
       - name: Check Circular Deps

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@prettier/plugin-xml": "^3.4.2",
     "@types/node": "^24",
     "@vitest/coverage-istanbul": "^4.1.10",
+    "@yarnpkg/types": "^4.0.1",
     "env-cmd": "^11.0.0",
     "madge": "^8.0.0",
     "prettier": "^3.9.6",

--- a/packages/converter-api/package.json
+++ b/packages/converter-api/package.json
@@ -30,6 +30,10 @@
     "clean": "rimraf lib coverage",
     "compile": "tsc"
   },
+  "devDependencies": {
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/converter-big-number/package.json
+++ b/packages/converter-big-number/package.json
@@ -33,7 +33,11 @@
     "@odata2ts/converter-api": "^0.2.6"
   },
   "devDependencies": {
-    "bignumber.js": "^11.1.5"
+    "bignumber.js": "^11.1.5",
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "peerDependencies": {
     "bignumber.js": ">1"

--- a/packages/converter-common/package.json
+++ b/packages/converter-common/package.json
@@ -34,6 +34,12 @@
   "dependencies": {
     "@odata2ts/converter-api": "^0.2.6"
   },
+  "devDependencies": {
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/converter-decimal/package.json
+++ b/packages/converter-decimal/package.json
@@ -33,7 +33,11 @@
     "@odata2ts/converter-api": "^0.2.6"
   },
   "devDependencies": {
-    "decimal.js": "^10.6.0"
+    "decimal.js": "^10.6.0",
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "peerDependencies": {
     "decimal.js": ">1"

--- a/packages/converter-luxon/package.json
+++ b/packages/converter-luxon/package.json
@@ -42,7 +42,11 @@
   },
   "devDependencies": {
     "@types/luxon": "^3.7.2",
-    "luxon": "^3.7.2"
+    "luxon": "^3.7.2",
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "peerDependencies": {
     "luxon": "^3.0.4"

--- a/packages/converter-runtime/package.json
+++ b/packages/converter-runtime/package.json
@@ -37,7 +37,11 @@
     "@odata2ts/converter-example": "^1.0.2",
     "@odata2ts/converter-luxon": "^0.2.7",
     "@odata2ts/converter-v2-to-v4": "^0.5.7",
-    "luxon": "^3.7.2"
+    "luxon": "^3.7.2",
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/converter-ui5-v2/package.json
+++ b/packages/converter-ui5-v2/package.json
@@ -36,6 +36,12 @@
     "@odata2ts/converter-common": "^0.3.7",
     "@odata2ts/converter-v2-to-v4": "^0.5.7"
   },
+  "devDependencies": {
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/converter-v2-to-v4/package.json
+++ b/packages/converter-v2-to-v4/package.json
@@ -39,6 +39,12 @@
   "dependencies": {
     "@odata2ts/converter-api": "^0.2.6"
   },
+  "devDependencies": {
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -1,0 +1,33 @@
+/**
+ * Yarn constraints: the root package.json is the single source of truth for dependency versions.
+ *
+ * Every workspace has to declare the tools its own scripts invoke — Yarn only exposes the binaries of
+ * dependencies a workspace declares itself (it does not fall back to the root's node_modules/.bin).
+ * That would invite version drift across a dozen package.json files, so this constraint pins every
+ * duplicated range back to whatever the root declares.
+ *
+ * Check: `yarn constraints` (also runs in CI) — fix: `yarn constraints --fix`.
+ */
+
+/** @type {import('@yarnpkg/types').Yarn.Config} */
+module.exports = {
+  constraints({ Yarn }) {
+    const root = Yarn.workspace({ cwd: "." });
+
+    // peerDependencies are excluded on purpose: they express what a consumer has to bring along
+    // (e.g. `decimal.js: ">1"`), not what this repo installs.
+    for (const dependency of [
+      ...Yarn.dependencies({ type: "dependencies" }),
+      ...Yarn.dependencies({ type: "devDependencies" }),
+    ]) {
+      if (dependency.workspace.cwd === root.cwd) continue;
+      // workspace:^ links resolve locally and have no root counterpart
+      if (dependency.range.startsWith("workspace:")) continue;
+
+      const rootDependency = Yarn.dependency({ workspace: root, ident: dependency.ident });
+      if (rootDependency) {
+        dependency.update(rootDependency.range);
+      }
+    }
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,6 +1074,9 @@ __metadata:
 "@odata2ts/converter-api@npm:^0.2.6, @odata2ts/converter-api@workspace:packages/converter-api":
   version: 0.0.0-use.local
   resolution: "@odata2ts/converter-api@workspace:packages/converter-api"
+  dependencies:
+    rimraf: "npm:^6.1.3"
+    typescript: "npm:6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -1083,6 +1086,10 @@ __metadata:
   dependencies:
     "@odata2ts/converter-api": "npm:^0.2.6"
     bignumber.js: "npm:^11.1.5"
+    madge: "npm:^8.0.0"
+    rimraf: "npm:^6.1.3"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   peerDependencies:
     bignumber.js: ">1"
   languageName: unknown
@@ -1093,6 +1100,10 @@ __metadata:
   resolution: "@odata2ts/converter-common@workspace:packages/converter-common"
   dependencies:
     "@odata2ts/converter-api": "npm:^0.2.6"
+    madge: "npm:^8.0.0"
+    rimraf: "npm:^6.1.3"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -1102,6 +1113,10 @@ __metadata:
   dependencies:
     "@odata2ts/converter-api": "npm:^0.2.6"
     decimal.js: "npm:^10.6.0"
+    madge: "npm:^8.0.0"
+    rimraf: "npm:^6.1.3"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   peerDependencies:
     decimal.js: ">1"
   languageName: unknown
@@ -1141,6 +1156,10 @@ __metadata:
     "@odata2ts/converter-api": "npm:^0.2.6"
     "@types/luxon": "npm:^3.7.2"
     luxon: "npm:^3.7.2"
+    madge: "npm:^8.0.0"
+    rimraf: "npm:^6.1.3"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   peerDependencies:
     luxon: ^3.0.4
   languageName: unknown
@@ -1182,6 +1201,10 @@ __metadata:
     "@odata2ts/converter-luxon": "npm:^0.2.7"
     "@odata2ts/converter-v2-to-v4": "npm:^0.5.7"
     luxon: "npm:^3.7.2"
+    madge: "npm:^8.0.0"
+    rimraf: "npm:^6.1.3"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -1192,6 +1215,10 @@ __metadata:
     "@odata2ts/converter-api": "npm:^0.2.6"
     "@odata2ts/converter-common": "npm:^0.3.7"
     "@odata2ts/converter-v2-to-v4": "npm:^0.5.7"
+    madge: "npm:^8.0.0"
+    rimraf: "npm:^6.1.3"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -1200,6 +1227,10 @@ __metadata:
   resolution: "@odata2ts/converter-v2-to-v4@workspace:packages/converter-v2-to-v4"
   dependencies:
     "@odata2ts/converter-api": "npm:^0.2.6"
+    madge: "npm:^8.0.0"
+    rimraf: "npm:^6.1.3"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -1211,6 +1242,7 @@ __metadata:
     "@prettier/plugin-xml": "npm:^3.4.2"
     "@types/node": "npm:^24"
     "@vitest/coverage-istanbul": "npm:^4.1.10"
+    "@yarnpkg/types": "npm:^4.0.1"
     env-cmd: "npm:^11.0.0"
     madge: "npm:^8.0.0"
     prettier: "npm:^3.9.6"
@@ -1936,6 +1968,15 @@ __metadata:
   dependencies:
     chevrotain: "npm:7.1.1"
   checksum: 10/df1aa7ac0ec81ec6363b515f4bb80043c8c29c2e2c87ba668f142d20090f8a67ae1bde3665ee63ebbca12dd9d77991795d97f02fa0e2e64c20ba7a0636209463
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/types@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@yarnpkg/types@npm:4.0.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/f391763cd955356e9aad551b29e8de7bbf68a6c8992af7cdc950ccf53f8aff6695ad81aa4c8a8e7c582786a840a4f30617732e2cb49f4109b971a9242c31c9fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Yarn only exposes the binaries of dependencies a workspace declares itself — there is no fallback to the root's `node_modules/.bin`. Running a script from within a package therefore failed with `command not found: rimraf` / `command not found: vitest`, while the same script via a root script worked, because the root passes its shim directory down through `PATH`.
- `typescript`, `vitest`, `rimraf` and `madge` are now declared in each of the eight packages, derived from the scripts each one actually runs (`converter-api` has neither tests nor a circular-deps check, so it only gets `rimraf` and `typescript`).
- Added `yarn.config.cjs` so the root `package.json` stays the single source of truth for versions: every `dependency`/`devDependency` of a workspace is pinned back to the root's range, `peerDependencies` deliberately excluded. Apply with `yarn constraints --fix`, verify with `yarn constraints`.
- `yarn constraints` runs in CI ahead of the build; verified it exits 1 on drift and 0 on parity.
- Verified all 22 `build` / `test` / `check-circular-deps` invocations across the eight packages now succeed individually, and the root `build`, `test` and `coverage` runs are unchanged (107 tests).