### PR TITLE
feat(converter-api)!: state a type's module explicitly instead of encoding it in a dotted string

### DIFF
--- a/examples/test-converters/src/StringToPrefixModelConverter.ts
+++ b/examples/test-converters/src/StringToPrefixModelConverter.ts
@@ -8,7 +8,7 @@ export interface PrefixModel {
 export const stringToPrefixModelConverter: ValueConverter<string, PrefixModel> = {
   id: "stringToPrefixModelConverter",
   from: "Edm.String",
-  to: "@odata2ts/test-converters.PrefixModel",
+  to: { module: "@odata2ts/test-converters", type: "PrefixModel" },
 
   convertFrom(value: ParamValueModel<string>): ParamValueModel<PrefixModel> {
     return typeof value === "string" ? { prefix: "PREFIX_", value } : value;

--- a/packages/converter-api/src/index.ts
+++ b/packages/converter-api/src/index.ts
@@ -15,19 +15,13 @@ export interface ConverterPackage {
 }
 
 /**
- * A type a converter reads from or writes to, stated explicitly.
- *
- * The shorthand {@code string} form encodes both parts in one dotted value ("luxon.DateTime") and is
- * resolved by splitting at the last dot. That works as long as the type name itself carries no dot, so
- * a type living in a namespace ("BigNumber.Instance") or a global one ("Intl.DateTimeFormat") cannot be
- * expressed that way - use this form for those.
+ * A type which has to be imported from a module.
  */
 export interface TypeReference {
   /**
    * The module the type has to be imported from, e.g. "bignumber.js".
-   * Omit it for built-in types such as "string" or "number", which need no import.
    */
-  module?: string;
+  module: string;
   /**
    * The type as it is written in code, e.g. "BigNumber.Instance". May be qualified.
    */
@@ -35,7 +29,14 @@ export interface TypeReference {
 }
 
 /**
- * Either the explicit {@link TypeReference} or its dotted shorthand, e.g. "luxon.DateTime".
+ * A type a converter reads from or writes to.
+ *
+ * A plain {@code string} is the type name verbatim and needs no import - "string", "number",
+ * "Edm.Boolean" or a global like "Intl.DateTimeFormat". It is never taken apart, so a dot in it is
+ * simply part of the name.
+ *
+ * Anything that has to be imported uses {@link TypeReference}, which keeps module and type apart
+ * instead of encoding both into one value.
  */
 export type TypeSpecification = string | TypeReference;
 

--- a/packages/converter-api/src/index.ts
+++ b/packages/converter-api/src/index.ts
@@ -15,6 +15,31 @@ export interface ConverterPackage {
 }
 
 /**
+ * A type a converter reads from or writes to, stated explicitly.
+ *
+ * The shorthand {@code string} form encodes both parts in one dotted value ("luxon.DateTime") and is
+ * resolved by splitting at the last dot. That works as long as the type name itself carries no dot, so
+ * a type living in a namespace ("BigNumber.Instance") or a global one ("Intl.DateTimeFormat") cannot be
+ * expressed that way - use this form for those.
+ */
+export interface TypeReference {
+  /**
+   * The module the type has to be imported from, e.g. "bignumber.js".
+   * Omit it for built-in types such as "string" or "number", which need no import.
+   */
+  module?: string;
+  /**
+   * The type as it is written in code, e.g. "BigNumber.Instance". May be qualified.
+   */
+  type: string;
+}
+
+/**
+ * Either the explicit {@link TypeReference} or its dotted shorthand, e.g. "luxon.DateTime".
+ */
+export type TypeSpecification = string | TypeReference;
+
+/**
  * Required meta information for any ValueConverter
  */
 export interface ValueConverterType {
@@ -27,11 +52,11 @@ export interface ValueConverterType {
   /**
    * The type or types which will be used as input for this converter.
    */
-  from: string | Array<string>;
+  from: TypeSpecification | Array<TypeSpecification>;
   /**
    * The output type of this converter.
    */
-  to: string;
+  to: TypeSpecification;
 }
 
 export interface ConverterOptions {

--- a/packages/converter-big-number/src/BigNumberConverter.ts
+++ b/packages/converter-big-number/src/BigNumberConverter.ts
@@ -4,7 +4,7 @@ import BigNumber from "bignumber.js";
 export const bigNumberConverter: ValueConverter<string, BigNumber.Instance> = {
   id: "bigNumberConverter",
   from: ["Edm.Int64", "Edm.Decimal"],
-  to: "bignumber.js.BigNumber",
+  to: { module: "bignumber.js", type: "BigNumber" },
 
   convertFrom: function (value: ParamValueModel<string>): ParamValueModel<BigNumber.Instance> {
     if (typeof value !== "string") {

--- a/packages/converter-common/src/SimpleDurationConverter.ts
+++ b/packages/converter-common/src/SimpleDurationConverter.ts
@@ -63,7 +63,7 @@ function format(value: number | null | undefined, suffix: string) {
 export const simpleDurationConverter: ValueConverter<string, SimpleDuration> = {
   id: "simpleDurationConverter",
   from: "Edm.Duration",
-  to: "@odata2ts/converter-common.SimpleDuration",
+  to: { module: "@odata2ts/converter-common", type: "SimpleDuration" },
 
   convertFrom: function (value: ParamValueModel<string>): ParamValueModel<SimpleDuration> {
     if (typeof value !== "string") {

--- a/packages/converter-common/src/SimpleTimeConverter.ts
+++ b/packages/converter-common/src/SimpleTimeConverter.ts
@@ -44,7 +44,7 @@ function format(value: number | null | undefined, suffix: string) {
 export const simpleTimeConverter: ValueConverter<string, SimpleTime> = {
   id: "simpleTimeConverter",
   from: "Edm.Time",
-  to: "@odata2ts/converter-common.SimpleTime",
+  to: { module: "@odata2ts/converter-common", type: "SimpleTime" },
 
   convertFrom: function (value: ParamValueModel<string>): ParamValueModel<SimpleTime> {
     if (typeof value !== "string") {

--- a/packages/converter-decimal/src/DecimalConverter.ts
+++ b/packages/converter-decimal/src/DecimalConverter.ts
@@ -6,7 +6,7 @@ export const decimalConverter: ValueConverter<string, Decimal> & {
 } = {
   id: "decimalConverter",
   from: ["Edm.Int64", "Edm.Decimal"],
-  to: "decimal.js.Decimal",
+  to: { module: "decimal.js", type: "Decimal" },
 
   convertFrom: function (value: ParamValueModel<string>): ParamValueModel<Decimal> {
     if (typeof value !== "string") {

--- a/packages/converter-luxon/src/DateTimeOffsetToLuxonConverter.ts
+++ b/packages/converter-luxon/src/DateTimeOffsetToLuxonConverter.ts
@@ -4,7 +4,7 @@ import { DateTime } from "luxon";
 export const dateTimeOffsetToLuxonConverter: ValueConverter<string, DateTime> = {
   id: "dateTimeOffsetToLuxonConverter",
   from: "Edm.DateTimeOffset",
-  to: "luxon.DateTime",
+  to: { module: "luxon", type: "DateTime" },
 
   convertFrom: function (value: ParamValueModel<string>): ParamValueModel<DateTime> {
     if (typeof value !== "string") {

--- a/packages/converter-luxon/src/DateToLuxonConverter.ts
+++ b/packages/converter-luxon/src/DateToLuxonConverter.ts
@@ -4,7 +4,7 @@ import { DateTime } from "luxon";
 export const dateToLuxonConverter: ValueConverter<string, DateTime> = {
   id: "dateToLuxonConverter",
   from: "Edm.Date",
-  to: "luxon.DateTime",
+  to: { module: "luxon", type: "DateTime" },
 
   convertFrom: function (value: ParamValueModel<string>): ParamValueModel<DateTime> {
     if (typeof value !== "string") {

--- a/packages/converter-luxon/src/DurationToLuxonConverter.ts
+++ b/packages/converter-luxon/src/DurationToLuxonConverter.ts
@@ -4,7 +4,7 @@ import { Duration } from "luxon";
 export const durationToLuxonConverter: ValueConverter<string, Duration> = {
   id: "durationToLuxonConverter",
   from: "Edm.Duration",
-  to: "luxon.Duration",
+  to: { module: "luxon", type: "Duration" },
 
   convertFrom: function (value: ParamValueModel<string>): ParamValueModel<Duration> {
     if (typeof value !== "string") {

--- a/packages/converter-luxon/src/TimeOfDayToLuxonConverter.ts
+++ b/packages/converter-luxon/src/TimeOfDayToLuxonConverter.ts
@@ -4,7 +4,7 @@ import { DateTime } from "luxon";
 export const timeOfDayToLuxonConverter: ValueConverter<string, DateTime> = {
   id: "timeOfDayToLuxonConverter",
   from: "Edm.TimeOfDay",
-  to: "luxon.DateTime",
+  to: { module: "luxon", type: "DateTime" },
 
   convertFrom: function (value: ParamValueModel<string>): ParamValueModel<DateTime> {
     if (typeof value !== "string") {

--- a/packages/converter-runtime/src/loadConverters.ts
+++ b/packages/converter-runtime/src/loadConverters.ts
@@ -33,7 +33,7 @@ function isConverterPackage(candidate: unknown): candidate is ConverterPackage {
   );
 }
 
-/** Accepts both the dotted shorthand and the explicit {@code { module?, type }} form. */
+/** Accepts a plain type name or a {@code { module, type }} reference. */
 function isTypeSpecification(candidate: unknown): candidate is TypeSpecification {
   if (typeof candidate === "string") {
     return !!candidate;
@@ -42,7 +42,7 @@ function isTypeSpecification(candidate: unknown): candidate is TypeSpecification
     return false;
   }
   const { module, type } = candidate as Exclude<TypeSpecification, string>;
-  return typeof type === "string" && !!type && (module === undefined || (typeof module === "string" && !!module));
+  return typeof type === "string" && !!type && typeof module === "string" && !!module;
 }
 
 /**
@@ -66,7 +66,7 @@ function describeConverter(candidate: unknown) {
 
 const CONVERTER_CONTRACT_HINT =
   `requires a non-empty string "id" plus "from" and "to", ` +
-  `each of them a non-empty type name, a { module?, type } object, or (for "from") an array of those`;
+  `each of them a plain type name, a { module, type } reference, or (for "from") an array of those`;
 
 async function doLoad(converters: Array<TypeConverterConfig>): Promise<Array<RuntimeConverterPackage>> {
   return Promise.all(
@@ -262,25 +262,10 @@ function chainConverters(
 }
 
 /**
- * Resolves the dotted shorthand form: everything up to the last dot is the module, the rest the type.
+ * Brings both forms of a {@code TypeSpecification} into the same [type, module?] shape.
  *
- * Only unambiguous as long as the type name carries no dot of its own - a namespaced type
- * ("BigNumber.Instance") or a global one ("Intl.DateTimeFormat") cannot be expressed this way, which is
- * what {@link TypeReference} is for.
- */
-export function getPropTypeAndModule(typeName: string) {
-  if (typeName.match(/\./)?.length && !typeName.startsWith("Edm.")) {
-    const separator = typeName.lastIndexOf(".");
-    const module = typeName.substring(0, separator);
-    const type = typeName.substring(separator + 1);
-    return [type, module];
-  }
-  return [typeName];
-}
-
-/**
- * Brings either form of a {@link TypeSpecification} into the same [type, module?] shape.
+ * A string is taken verbatim and never split - a dot in it belongs to the type name.
  */
 export function resolveTypeSpec(spec: TypeSpecification): [string, string?] {
-  return typeof spec === "string" ? (getPropTypeAndModule(spec) as [string, string?]) : [spec.type, spec.module];
+  return typeof spec === "string" ? [spec] : [spec.type, spec.module];
 }

--- a/packages/converter-runtime/src/loadConverters.ts
+++ b/packages/converter-runtime/src/loadConverters.ts
@@ -1,4 +1,4 @@
-import { ConverterPackage, ValueConverterType } from "@odata2ts/converter-api";
+import { ConverterPackage, TypeSpecification, ValueConverterType } from "@odata2ts/converter-api";
 import { ODataTypesV2, ODataTypesV4, ODataVersions } from "@odata2ts/odata-core";
 import {
   RuntimeConverterPackage,
@@ -7,7 +7,14 @@ import {
   ValueConverterImport,
 } from "./ConverterModels";
 
-type MappedConverter = ValueConverterType & { package: string; toModule?: string };
+// "from" and "to" are narrowed back to plain strings on purpose: whichever form the converter used,
+// this stage has already resolved it, and the module travels separately in "toModule"
+type MappedConverter = Omit<ValueConverterType, "from" | "to"> & {
+  package: string;
+  from: string;
+  to: string;
+  toModule?: string;
+};
 // we use an array of converters because of converters which fix stuff, mapping from and to the identical type
 type MappedConverters = Map<string, Array<MappedConverter>>;
 
@@ -26,6 +33,18 @@ function isConverterPackage(candidate: unknown): candidate is ConverterPackage {
   );
 }
 
+/** Accepts both the dotted shorthand and the explicit {@code { module?, type }} form. */
+function isTypeSpecification(candidate: unknown): candidate is TypeSpecification {
+  if (typeof candidate === "string") {
+    return !!candidate;
+  }
+  if (!candidate || typeof candidate !== "object") {
+    return false;
+  }
+  const { module, type } = candidate as Exclude<TypeSpecification, string>;
+  return typeof type === "string" && !!type && (module === undefined || (typeof module === "string" && !!module));
+}
+
 /**
  * Checks the meta information every converter must provide, no matter how it was loaded.
  * Without this the first malformed converter surfaces as a TypeError deep within the mapping step,
@@ -36,11 +55,8 @@ function isValueConverter(candidate: unknown): candidate is ValueConverterType {
     return false;
   }
   const { id, from, to } = candidate as ValueConverterType;
-  const validFrom =
-    typeof from === "string"
-      ? !!from
-      : Array.isArray(from) && !!from.length && from.every((f) => !!f && typeof f === "string");
-  return typeof id === "string" && !!id && validFrom && typeof to === "string" && !!to;
+  const validFrom = Array.isArray(from) ? !!from.length && from.every(isTypeSpecification) : isTypeSpecification(from);
+  return typeof id === "string" && !!id && validFrom && isTypeSpecification(to);
 }
 
 function describeConverter(candidate: unknown) {
@@ -48,7 +64,9 @@ function describeConverter(candidate: unknown) {
   return typeof id === "string" && id ? `Converter "${id}"` : "Converter";
 }
 
-const CONVERTER_CONTRACT_HINT = `requires a non-empty string "id", a non-empty string or string array "from" and a non-empty string "to"`;
+const CONVERTER_CONTRACT_HINT =
+  `requires a non-empty string "id" plus "from" and "to", ` +
+  `each of them a non-empty type name, a { module?, type } object, or (for "from") an array of those`;
 
 async function doLoad(converters: Array<TypeConverterConfig>): Promise<Array<RuntimeConverterPackage>> {
   return Promise.all(
@@ -116,10 +134,10 @@ async function doLoad(converters: Array<TypeConverterConfig>): Promise<Array<Run
 function mapConvertersBySource(converterPkgs: Array<RuntimeConverterPackage>): MappedConverters {
   return converterPkgs.reduce<MappedConverters>((collector, converterPkg) => {
     for (let converter of converterPkg.converters) {
-      const froms = typeof converter.from === "string" ? [converter.from] : converter.from;
+      const froms = Array.isArray(converter.from) ? converter.from : [converter.from];
       for (let from of froms) {
-        const [fromType] = getPropTypeAndModule(from);
-        const [toType, toModule] = getPropTypeAndModule(converter.to);
+        const [fromType] = resolveTypeSpec(from);
+        const [toType, toModule] = resolveTypeSpec(converter.to);
 
         const result: MappedConverter = {
           package: converterPkg.package,
@@ -129,11 +147,14 @@ function mapConvertersBySource(converterPkgs: Array<RuntimeConverterPackage>): M
           toModule,
         };
 
-        const prev = collector.get(from);
+        // keyed by the resolved type, because that is what chaining looks up: the "to" of the
+        // preceding converter arrives here without its module, so keying by the raw value would
+        // leave any module-qualified "from" unreachable
+        const prev = collector.get(fromType);
         if (prev?.length && prev[prev.length - 1].to === fromType) {
           prev.push(result);
         } else {
-          collector.set(from, [result]);
+          collector.set(fromType, [result]);
         }
       }
     }
@@ -240,6 +261,13 @@ function chainConverters(
   };
 }
 
+/**
+ * Resolves the dotted shorthand form: everything up to the last dot is the module, the rest the type.
+ *
+ * Only unambiguous as long as the type name carries no dot of its own - a namespaced type
+ * ("BigNumber.Instance") or a global one ("Intl.DateTimeFormat") cannot be expressed this way, which is
+ * what {@link TypeReference} is for.
+ */
 export function getPropTypeAndModule(typeName: string) {
   if (typeName.match(/\./)?.length && !typeName.startsWith("Edm.")) {
     const separator = typeName.lastIndexOf(".");
@@ -248,4 +276,11 @@ export function getPropTypeAndModule(typeName: string) {
     return [type, module];
   }
   return [typeName];
+}
+
+/**
+ * Brings either form of a {@link TypeSpecification} into the same [type, module?] shape.
+ */
+export function resolveTypeSpec(spec: TypeSpecification): [string, string?] {
+  return typeof spec === "string" ? (getPropTypeAndModule(spec) as [string, string?]) : [spec.type, spec.module];
 }

--- a/packages/converter-runtime/test/fixture/invalid-type-reference.mjs
+++ b/packages/converter-runtime/test/fixture/invalid-type-reference.mjs
@@ -1,0 +1,5 @@
+// A TypeReference without the mandatory "type".
+export default {
+  id: "InvalidTypeReference",
+  converters: [{ id: "noTypeConverter", from: "Edm.String", to: { module: "luxon" } }],
+};

--- a/packages/converter-runtime/test/fixture/type-reference-source.mjs
+++ b/packages/converter-runtime/test/fixture/type-reference-source.mjs
@@ -1,5 +1,5 @@
-// Produces a module-qualified type using the shorthand ...
+// Produces an imported type ...
 export default {
   id: "TypeReferenceSource",
-  converters: [{ id: "toLuxonShorthand", from: "Edm.DateTimeOffset", to: "luxon.DateTime" }],
+  converters: [{ id: "toLuxon", from: "Edm.DateTimeOffset", to: { module: "luxon", type: "DateTime" } }],
 };

--- a/packages/converter-runtime/test/fixture/type-reference-source.mjs
+++ b/packages/converter-runtime/test/fixture/type-reference-source.mjs
@@ -1,0 +1,5 @@
+// Produces a module-qualified type using the shorthand ...
+export default {
+  id: "TypeReferenceSource",
+  converters: [{ id: "toLuxonShorthand", from: "Edm.DateTimeOffset", to: "luxon.DateTime" }],
+};

--- a/packages/converter-runtime/test/fixture/type-reference-target-plain.mjs
+++ b/packages/converter-runtime/test/fixture/type-reference-target-plain.mjs
@@ -1,0 +1,5 @@
+// ... and this one through the bare type name, which is all the chaining matches on.
+export default {
+  id: "TypeReferenceTargetPlain",
+  converters: [{ id: "fromLuxonPlain", from: "DateTime", to: "string" }],
+};

--- a/packages/converter-runtime/test/fixture/type-reference-target-shorthand.mjs
+++ b/packages/converter-runtime/test/fixture/type-reference-target-shorthand.mjs
@@ -1,0 +1,4 @@
+export default {
+  id: "TypeReferenceTargetShorthand",
+  converters: [{ id: "fromLuxonShorthand", from: "luxon.DateTime", to: "string" }],
+};

--- a/packages/converter-runtime/test/fixture/type-reference-target-shorthand.mjs
+++ b/packages/converter-runtime/test/fixture/type-reference-target-shorthand.mjs
@@ -1,4 +1,0 @@
-export default {
-  id: "TypeReferenceTargetShorthand",
-  converters: [{ id: "fromLuxonShorthand", from: "luxon.DateTime", to: "string" }],
-};

--- a/packages/converter-runtime/test/fixture/type-reference-target.mjs
+++ b/packages/converter-runtime/test/fixture/type-reference-target.mjs
@@ -1,5 +1,5 @@
-// ... which this one picks up again, once through each form.
+// ... which this one picks up through the very same reference.
 export default {
   id: "TypeReferenceTarget",
-  converters: [{ id: "fromLuxonExplicit", from: { module: "luxon", type: "DateTime" }, to: "string" }],
+  converters: [{ id: "fromLuxonReference", from: { module: "luxon", type: "DateTime" }, to: "string" }],
 };

--- a/packages/converter-runtime/test/fixture/type-reference-target.mjs
+++ b/packages/converter-runtime/test/fixture/type-reference-target.mjs
@@ -1,0 +1,5 @@
+// ... which this one picks up again, once through each form.
+export default {
+  id: "TypeReferenceTarget",
+  converters: [{ id: "fromLuxonExplicit", from: { module: "luxon", type: "DateTime" }, to: "string" }],
+};

--- a/packages/converter-runtime/test/fixture/type-reference.mjs
+++ b/packages/converter-runtime/test/fixture/type-reference.mjs
@@ -1,11 +1,11 @@
-// The two cases the dotted shorthand cannot express.
+// The two cases the removed dot notation could not express.
 export default {
   id: "TypeReference",
   converters: [
-    // a type living in a namespace: splitting "bignumber.js.BigNumber.Instance" at the last dot
-    // would yield the module "bignumber.js.BigNumber"
+    // a type living in a namespace: "bignumber.js.BigNumber.Instance" used to resolve to the
+    // module "bignumber.js.BigNumber"
     { id: "toNamespacedType", from: "Edm.Decimal", to: { module: "bignumber.js", type: "BigNumber.Instance" } },
-    // a global that needs no import at all, yet carries a dot
-    { id: "toGlobalType", from: "Edm.String", to: { type: "Intl.DateTimeFormat" } },
+    // a global that needs no import at all, yet carries a dot - a plain string is taken verbatim now
+    { id: "toGlobalType", from: "Edm.String", to: "Intl.DateTimeFormat" },
   ],
 };

--- a/packages/converter-runtime/test/fixture/type-reference.mjs
+++ b/packages/converter-runtime/test/fixture/type-reference.mjs
@@ -1,0 +1,11 @@
+// The two cases the dotted shorthand cannot express.
+export default {
+  id: "TypeReference",
+  converters: [
+    // a type living in a namespace: splitting "bignumber.js.BigNumber.Instance" at the last dot
+    // would yield the module "bignumber.js.BigNumber"
+    { id: "toNamespacedType", from: "Edm.Decimal", to: { module: "bignumber.js", type: "BigNumber.Instance" } },
+    // a global that needs no import at all, yet carries a dot
+    { id: "toGlobalType", from: "Edm.String", to: { type: "Intl.DateTimeFormat" } },
+  ],
+};

--- a/packages/converter-runtime/test/loadConverter.test.ts
+++ b/packages/converter-runtime/test/loadConverter.test.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from "node:url";
 import { ValueConverterChain } from "@odata2ts/converter-runtime";
 import { ODataTypesV2, ODataTypesV4, ODataVersions } from "@odata2ts/odata-core";
 import { describe, expect, test } from "vitest";
-import { getPropTypeAndModule, loadConverters, resolveTypeSpec } from "../src";
+import { loadConverters, resolveTypeSpec } from "../src";
 
 const fixture = (name: string) => fileURLToPath(new URL(`./fixture/${name}`, import.meta.url));
 
@@ -204,29 +204,24 @@ describe("LoadConverters Test", () => {
     expect(result?.get(ODataTypesV4.String)).toMatchObject({ from: ODataTypesV4.String, to: "number" });
   });
 
-  test("getPropTypeAndModule", () => {
-    expect(getPropTypeAndModule("aba")).toStrictEqual(["aba"]);
-    expect(getPropTypeAndModule("AbA")).toStrictEqual(["AbA"]);
-    expect(getPropTypeAndModule("aba.ts")).toStrictEqual(["ts", "aba"]);
-    expect(getPropTypeAndModule("aba.js.Type")).toStrictEqual(["Type", "aba.js"]);
-  });
-
-  test("resolveTypeSpec handles both forms alike", () => {
-    expect(resolveTypeSpec("luxon.DateTime")).toStrictEqual(["DateTime", "luxon"]);
+  test("resolveTypeSpec never takes a string apart", () => {
     expect(resolveTypeSpec("string")).toStrictEqual(["string"]);
+    // a dot belongs to the type name - these are globals needing no import, not module-qualified types
+    expect(resolveTypeSpec("Edm.Boolean")).toStrictEqual(["Edm.Boolean"]);
+    expect(resolveTypeSpec("Intl.DateTimeFormat")).toStrictEqual(["Intl.DateTimeFormat"]);
+
     expect(resolveTypeSpec({ module: "luxon", type: "DateTime" })).toStrictEqual(["DateTime", "luxon"]);
-    // the explicit form is what makes a qualified type name expressible at all
+    // keeping the two apart is what makes a qualified type name expressible at all
     expect(resolveTypeSpec({ module: "bignumber.js", type: "BigNumber.Instance" })).toStrictEqual([
       "BigNumber.Instance",
       "bignumber.js",
     ]);
-    expect(resolveTypeSpec({ type: "Intl.DateTimeFormat" })).toStrictEqual(["Intl.DateTimeFormat", undefined]);
   });
 
-  describe("explicit type reference", () => {
+  describe("type reference", () => {
     test("a namespaced type keeps its module separate", async () => {
-      // the shorthand would split "bignumber.js.BigNumber.Instance" into the module
-      // "bignumber.js.BigNumber" - there is no spelling of it that works
+      // the removed dot notation would have split "bignumber.js.BigNumber.Instance" into the module
+      // "bignumber.js.BigNumber" - there was no spelling of it that worked
       const result = await loadConverters(ODataVersions.V4, [fixture("type-reference.mjs")]);
 
       expect(result?.get(ODataTypesV4.Decimal)).toMatchObject({
@@ -236,6 +231,7 @@ describe("LoadConverters Test", () => {
     });
 
     test("a global type gets no module invented for it", async () => {
+      // "Intl.DateTimeFormat" as a plain string is a type name, not a module plus a type
       const result = await loadConverters(ODataVersions.V4, [fixture("type-reference.mjs")]);
 
       expect(result?.get(ODataTypesV4.String)).toMatchObject({
@@ -244,17 +240,17 @@ describe("LoadConverters Test", () => {
       });
     });
 
-    test("both forms chain into each other", async () => {
-      // whichever way the producing and the consuming converter spell the type, they have to meet
-      for (const target of ["type-reference-target.mjs", "type-reference-target-shorthand.mjs"]) {
+    test("a reference and a plain name meet when chaining", async () => {
+      // chaining matches on the type alone, so the consuming converter may name the module or not
+      for (const [target, consumerId] of [
+        ["type-reference-target.mjs", "fromLuxonReference"],
+        ["type-reference-target-plain.mjs", "fromLuxonPlain"],
+      ]) {
         const result = await loadConverters(ODataVersions.V4, [fixture("type-reference-source.mjs"), fixture(target)]);
 
         expect(result?.get(ODataTypesV4.DateTimeOffset)).toMatchObject({
           to: "string",
-          converters: [
-            { converterId: "toLuxonShorthand" },
-            { converterId: target.includes("shorthand") ? "fromLuxonShorthand" : "fromLuxonExplicit" },
-          ],
+          converters: [{ converterId: "toLuxon" }, { converterId: consumerId }],
         });
       }
     });

--- a/packages/converter-runtime/test/loadConverter.test.ts
+++ b/packages/converter-runtime/test/loadConverter.test.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from "node:url";
 import { ValueConverterChain } from "@odata2ts/converter-runtime";
 import { ODataTypesV2, ODataTypesV4, ODataVersions } from "@odata2ts/odata-core";
 import { describe, expect, test } from "vitest";
-import { getPropTypeAndModule, loadConverters } from "../src";
+import { getPropTypeAndModule, loadConverters, resolveTypeSpec } from "../src";
 
 const fixture = (name: string) => fileURLToPath(new URL(`./fixture/${name}`, import.meta.url));
 
@@ -209,6 +209,61 @@ describe("LoadConverters Test", () => {
     expect(getPropTypeAndModule("AbA")).toStrictEqual(["AbA"]);
     expect(getPropTypeAndModule("aba.ts")).toStrictEqual(["ts", "aba"]);
     expect(getPropTypeAndModule("aba.js.Type")).toStrictEqual(["Type", "aba.js"]);
+  });
+
+  test("resolveTypeSpec handles both forms alike", () => {
+    expect(resolveTypeSpec("luxon.DateTime")).toStrictEqual(["DateTime", "luxon"]);
+    expect(resolveTypeSpec("string")).toStrictEqual(["string"]);
+    expect(resolveTypeSpec({ module: "luxon", type: "DateTime" })).toStrictEqual(["DateTime", "luxon"]);
+    // the explicit form is what makes a qualified type name expressible at all
+    expect(resolveTypeSpec({ module: "bignumber.js", type: "BigNumber.Instance" })).toStrictEqual([
+      "BigNumber.Instance",
+      "bignumber.js",
+    ]);
+    expect(resolveTypeSpec({ type: "Intl.DateTimeFormat" })).toStrictEqual(["Intl.DateTimeFormat", undefined]);
+  });
+
+  describe("explicit type reference", () => {
+    test("a namespaced type keeps its module separate", async () => {
+      // the shorthand would split "bignumber.js.BigNumber.Instance" into the module
+      // "bignumber.js.BigNumber" - there is no spelling of it that works
+      const result = await loadConverters(ODataVersions.V4, [fixture("type-reference.mjs")]);
+
+      expect(result?.get(ODataTypesV4.Decimal)).toMatchObject({
+        to: "BigNumber.Instance",
+        toModule: "bignumber.js",
+      });
+    });
+
+    test("a global type gets no module invented for it", async () => {
+      const result = await loadConverters(ODataVersions.V4, [fixture("type-reference.mjs")]);
+
+      expect(result?.get(ODataTypesV4.String)).toMatchObject({
+        to: "Intl.DateTimeFormat",
+        toModule: undefined,
+      });
+    });
+
+    test("both forms chain into each other", async () => {
+      // whichever way the producing and the consuming converter spell the type, they have to meet
+      for (const target of ["type-reference-target.mjs", "type-reference-target-shorthand.mjs"]) {
+        const result = await loadConverters(ODataVersions.V4, [fixture("type-reference-source.mjs"), fixture(target)]);
+
+        expect(result?.get(ODataTypesV4.DateTimeOffset)).toMatchObject({
+          to: "string",
+          converters: [
+            { converterId: "toLuxonShorthand" },
+            { converterId: target.includes("shorthand") ? "fromLuxonShorthand" : "fromLuxonExplicit" },
+          ],
+        });
+      }
+    });
+
+    test("a type reference without a type is rejected", async () => {
+      await expect(loadConverters(ODataVersions.V4, [fixture("invalid-type-reference.mjs")])).rejects.toThrow(
+        /Converter "noTypeConverter" at index 0 of module ".*" is not a valid converter/,
+      );
+    });
   });
 
   test("with fixing converter in between", async () => {

--- a/packages/converter-ui5-v2/src/TimeToMsDurationConverter.ts
+++ b/packages/converter-ui5-v2/src/TimeToMsDurationConverter.ts
@@ -8,7 +8,7 @@ export interface MsDuration {
 export const timeToMsDurationConverter: ValueConverter<string, MsDuration> = {
   id: "timeToMsDurationConverter",
   from: "Edm.Time",
-  to: "@odata2ts/converter-ui5-v2.MsDuration",
+  to: { module: "@odata2ts/converter-ui5-v2", type: "MsDuration" },
 
   convertFrom: function (value: ParamValueModel<string>): ParamValueModel<MsDuration> {
     if (typeof value !== "string") {


### PR DESCRIPTION
- `from` and `to` encoded module and type in one dotted value (`"luxon.DateTime"`), resolved by splitting at the last dot. The type name could therefore carry no dot of its own, which made two kinds of type inexpressible:
  - one living in a namespace — bignumber.js' actual instance type is `BigNumber.Instance`, and `"bignumber.js.BigNumber.Instance"` resolved to the module `"bignumber.js.BigNumber"`
  - a global one — `"Intl.DateTimeFormat"` resolved to an import from the non-existent module `"Intl"`
- There is now exactly one way to say each thing: a plain string is the type name, verbatim and never taken apart (`"string"`, `"Edm.Boolean"`, `"Intl.DateTimeFormat"`); anything that has to be imported is a `TypeReference`, `{ module, type }`.
- All converters in this repo were moved over. Those without a module (`"number"`, `"string"`, `"Date"`, `"bigint"`, the Edm types) are unchanged.
- While chaining, converters are now keyed by the **resolved** type rather than by the raw `from`. The recursion looks up the preceding converter's `to`, which has always arrived without its module, so a module-qualified `from` never chained at all — only the bare name did. A reference and a plain name now meet.
- `getPropTypeAndModule()` is gone, since splitting is what was removed; `resolveTypeSpec()` takes its place. Validation accepts both forms and rejects a `TypeReference` missing `module` or `type`.

**BREAKING CHANGE:** `from`/`to` no longer split a string at the last dot. A third-party converter still declaring `to: "luxon.DateTime"` now means a type of that literal name and gets no import — it has to become `to: { module: "luxon", type: "DateTime" }`. Deliberately not auto-detected: guessing whether a dot separates a module is the behaviour being removed, and it would misread a legitimate global like `"Intl.DateTimeFormat"`. The export `getPropTypeAndModule` was removed from `@odata2ts/converter-runtime`.

**Follow-up needed in odata2ts:** `to` can now resolve to a qualified type name, which `ImportContainer.addCustomType` cannot emit — it would produce `import { BigNumber.Instance } from "bignumber.js"`. The namespaced case only pays off end to end once that is handled.
