### PR TITLE
fix(converter-big-number): type the converter on BigNumber, not BigNumber.Instance

### DIFF
--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -18,11 +18,11 @@
     "test": "yarn compile & vitest run"
   },
   "dependencies": {
-    "@odata2ts/converter-big-number": "^0.2.4",
-    "@odata2ts/converter-common": "^0.3.4",
-    "@odata2ts/converter-luxon": "^0.2.4",
-    "@odata2ts/converter-runtime": "^0.5.1",
-    "@odata2ts/converter-v2-to-v4": "^0.5.4",
+    "@odata2ts/converter-big-number": "^0.3.0",
+    "@odata2ts/converter-common": "^0.4.0",
+    "@odata2ts/converter-luxon": "^0.3.0",
+    "@odata2ts/converter-runtime": "^0.6.0",
+    "@odata2ts/converter-v2-to-v4": "^0.5.8",
     "@odata2ts/odata-query-objects": "^0.17.3",
     "bignumber.js": "^11.1.5"
   },

--- a/packages/converter-big-number/src/BigNumberConverter.ts
+++ b/packages/converter-big-number/src/BigNumberConverter.ts
@@ -1,17 +1,17 @@
 import { ParamValueModel, ValueConverter } from "@odata2ts/converter-api";
 import BigNumber from "bignumber.js";
 
-export const bigNumberConverter: ValueConverter<string, BigNumber.Instance> = {
+export const bigNumberConverter: ValueConverter<string, BigNumber> = {
   id: "bigNumberConverter",
   from: ["Edm.Int64", "Edm.Decimal"],
   to: { module: "bignumber.js", type: "BigNumber" },
 
-  convertFrom: function (value: ParamValueModel<string>): ParamValueModel<BigNumber.Instance> {
+  convertFrom: function (value: ParamValueModel<string>): ParamValueModel<BigNumber> {
     if (typeof value !== "string") {
       return value;
     }
 
-    let result: BigNumber.Instance;
+    let result: BigNumber;
     try {
       // bignumber.js v11+ throws on construction for an invalid value; v9 silently
       // produced a NaN-valued instance instead, which the check below used to catch
@@ -25,7 +25,7 @@ export const bigNumberConverter: ValueConverter<string, BigNumber.Instance> = {
     return result;
   },
 
-  convertTo: function (value: ParamValueModel<BigNumber.Instance>): ParamValueModel<string> {
+  convertTo: function (value: ParamValueModel<BigNumber>): ParamValueModel<string> {
     if (value === undefined || value === null) {
       return value;
     }

--- a/packages/converter-big-number/test/BigNumberConverter.test.ts
+++ b/packages/converter-big-number/test/BigNumberConverter.test.ts
@@ -1,11 +1,28 @@
+import { ParamValueModel } from "@odata2ts/converter-api";
 import BigNumber from "bignumber.js";
-import { describe, expect, test } from "vitest";
+import { describe, expect, expectTypeOf, test } from "vitest";
 import { bigNumberConverter } from "../src";
 
 describe("BigNumberConverter Test", () => {
   const FROM_STRING = "123.01234567890123456789";
 
   const TO_TEST = bigNumberConverter;
+
+  test("the declared target type is the class, and it is the one produced", () => {
+    /*
+     * `BigNumber.Instance` is not the instance type: it declares `c`, `e` and `s` plus an index
+     * signature and exists for the `BigNumber.Value` union, so that an instance from another copy of
+     * the library can be passed to the constructor. Typing this converter on it silently degrades
+     * every method call on a converted value to `any`. The class is the instance type, and `to` has
+     * to name exactly that, or the generated client types a property on one and gets the other.
+     */
+    expect(TO_TEST.to).toStrictEqual({ module: "bignumber.js", type: "BigNumber" });
+
+    const candidate = TO_TEST.convertFrom(FROM_STRING);
+    expectTypeOf(candidate).toEqualTypeOf<ParamValueModel<BigNumber>>();
+    // via BigNumber.Instance this would be `any`
+    expectTypeOf(candidate!.toFixed(2)).toEqualTypeOf<string>();
+  });
 
   test("conversion", () => {
     const candidate = TO_TEST.convertFrom(FROM_STRING);

--- a/yarn.lock
+++ b/yarn.lock
@@ -785,17 +785,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@odata2ts/converter-big-number@npm:^0.2.4":
-  version: 0.2.8
-  resolution: "@odata2ts/converter-big-number@npm:0.2.8"
-  dependencies:
-    "@odata2ts/converter-api": "npm:^0.2.6"
-    bignumber.js: "npm:>1"
-  checksum: 10/ba0f176bf492d2b33f75deb85eeb5fb763a4e47b50335bfdf31e924f1f760234ef3599a8ac82d83253ce3ec52783eddf3422a0f2e696b2291bf2a202769099ed
-  languageName: node
-  linkType: hard
-
-"@odata2ts/converter-big-number@workspace:packages/converter-big-number":
+"@odata2ts/converter-big-number@npm:^0.3.0, @odata2ts/converter-big-number@workspace:packages/converter-big-number":
   version: 0.0.0-use.local
   resolution: "@odata2ts/converter-big-number@workspace:packages/converter-big-number"
   dependencies:
@@ -810,7 +800,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@odata2ts/converter-common@npm:^0.3.4, @odata2ts/converter-common@npm:^0.3.7":
+"@odata2ts/converter-common@npm:^0.3.7":
   version: 0.3.7
   resolution: "@odata2ts/converter-common@npm:0.3.7"
   dependencies:
@@ -873,17 +863,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@odata2ts/converter-luxon@npm:^0.2.4":
-  version: 0.2.7
-  resolution: "@odata2ts/converter-luxon@npm:0.2.7"
-  dependencies:
-    "@odata2ts/converter-api": "npm:^0.2.6"
-  peerDependencies:
-    luxon: ^3.0.4
-  checksum: 10/3abef42f5b15f65d2f4c7d17fd6d92aa2e7ffd400427eac0cdc1a50eed77ad937797e089998ab48e0c7719990125d2170473b100ef23c5503206504e8f5a1460
-  languageName: node
-  linkType: hard
-
 "@odata2ts/converter-luxon@npm:^0.3.0, @odata2ts/converter-luxon@workspace:packages/converter-luxon":
   version: 0.0.0-use.local
   resolution: "@odata2ts/converter-luxon@workspace:packages/converter-luxon"
@@ -904,11 +883,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@odata2ts/converter-playground@workspace:examples/playground"
   dependencies:
-    "@odata2ts/converter-big-number": "npm:^0.2.4"
-    "@odata2ts/converter-common": "npm:^0.3.4"
-    "@odata2ts/converter-luxon": "npm:^0.2.4"
-    "@odata2ts/converter-runtime": "npm:^0.5.1"
-    "@odata2ts/converter-v2-to-v4": "npm:^0.5.4"
+    "@odata2ts/converter-big-number": "npm:^0.3.0"
+    "@odata2ts/converter-common": "npm:^0.4.0"
+    "@odata2ts/converter-luxon": "npm:^0.3.0"
+    "@odata2ts/converter-runtime": "npm:^0.6.0"
+    "@odata2ts/converter-v2-to-v4": "npm:^0.5.8"
     "@odata2ts/odata-query-objects": "npm:^0.17.3"
     "@types/node": "npm:^24"
     bignumber.js: "npm:^11.1.5"
@@ -927,16 +906,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@odata2ts/converter-runtime@npm:^0.5.1":
-  version: 0.5.5
-  resolution: "@odata2ts/converter-runtime@npm:0.5.5"
-  dependencies:
-    "@odata2ts/converter-api": "npm:^0.2.6"
-  checksum: 10/798e65e65b6db0eb04e5fa3e642bfd3ac6ad9e2a2d217b65599abe10e084d90b89e0f88a36de044283b8f9c249c230fb7b594708e79bfcb3d0659aea261bf7b5
-  languageName: node
-  linkType: hard
-
-"@odata2ts/converter-runtime@workspace:packages/converter-runtime":
+"@odata2ts/converter-runtime@npm:^0.6.0, @odata2ts/converter-runtime@workspace:packages/converter-runtime":
   version: 0.0.0-use.local
   resolution: "@odata2ts/converter-runtime@workspace:packages/converter-runtime"
   dependencies:
@@ -977,7 +947,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@odata2ts/converter-v2-to-v4@npm:^0.5.4, @odata2ts/converter-v2-to-v4@npm:^0.5.7, @odata2ts/converter-v2-to-v4@npm:^0.5.8, @odata2ts/converter-v2-to-v4@workspace:packages/converter-v2-to-v4":
+"@odata2ts/converter-v2-to-v4@npm:^0.5.7, @odata2ts/converter-v2-to-v4@npm:^0.5.8, @odata2ts/converter-v2-to-v4@workspace:packages/converter-v2-to-v4":
   version: 0.0.0-use.local
   resolution: "@odata2ts/converter-v2-to-v4@workspace:packages/converter-v2-to-v4"
   dependencies:
@@ -1992,7 +1962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:>1, bignumber.js@npm:^11.1.5":
+"bignumber.js@npm:^11.1.5":
   version: 11.1.5
   resolution: "bignumber.js@npm:11.1.5"
   checksum: 10/79a5ff40e2459497f4e4023a305ac134cda2ff97f2f4c97847b55f552ea2dae1e9e2330df0f05c2f3fcf63f469bbff35dabe44ca444a23ecb3c900779672c30f


### PR DESCRIPTION
The v11 update typed this converter `ValueConverter<string, BigNumber.Instance>`, reading that name as the instance type. It is not one — bignumber.js declares:

```ts
interface Instance { readonly c; readonly e; readonly s; [key: string]: any }
type Value = string | number | bigint | Instance
declare class BigNumber implements BigNumber.Instance { /* ~50 methods */ }
```

`Instance` is a minimal structural shape that exists for the `BigNumber.Value` union, so an instance originating from another copy of the library can be passed to the constructor. The instance type is the class.

- Typing the converter on `Instance` was a **silent loss of type safety** for everyone using it: every method call on a converted value resolved through the index signature to `any`. Verified with the compiler — `asInstance.toFixed(2)` is `any`, `asClass.toFixed(2)` is `string`.
- It also broke generated clients outright, because `to` correctly named `BigNumber` while the signature said otherwise: `Type 'PrimitiveTypeServiceV2<Instance>' is not assignable to type 'PrimitiveTypeServiceV2<BigNumber>'`. Found by type-checking the generated `int-test/olingo-v2` and `int-test/cap` clients in odata2ts against the released 0.3.0.
- The `to` metadata is unchanged — it was right all along. The default import also stays: that half of the v11 update was correct, `export = BigNumber` offers no named export. Only the type reference was wrong.
- The new test pins the metadata and the produced type next to each other and asserts `toFixed` yields `string`, which is what fails first should `Instance` creep back in.

Second commit, found while chasing the above: `examples/playground` still asked for `^0.2.4` and friends, so after the 0.3.0 release its ranges no longer matched the workspaces and a fresh install resolved those packages from npm instead of linking them — its tests ran against the published converters rather than the working tree. A stale `node_modules` hid that locally.
