### PR TITLE
build(converter-big-number): publish an ESM build alongside the CommonJS one

### DIFF
--- a/packages/converter-big-number/package.json
+++ b/packages/converter-big-number/package.json
@@ -15,7 +15,21 @@
   "license": "MIT",
   "author": "texttechne",
   "type": "commonjs",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./lib/esm/index.d.ts",
+        "default": "./lib/esm/index.js"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "main": "./lib/index.js",
+  "module": "./lib/esm/index.js",
   "types": "./lib/index.d.ts",
   "files": [
     "*.md",
@@ -26,7 +40,8 @@
     "build": "yarn clean && yarn compile",
     "check-circular-deps": "madge ./src --extensions ts --circular",
     "clean": "rimraf lib coverage",
-    "compile": "tsc",
+    "compile": "tsc && tsc -p tsconfig.esm.json && yarn mark-esm",
+    "mark-esm": "node -e \"require('fs').writeFileSync('lib/esm/package.json', JSON.stringify({type:'module'}) + '\\n')\"",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/converter-big-number/src/index.ts
+++ b/packages/converter-big-number/src/index.ts
@@ -1,5 +1,5 @@
 import { ConverterPackage } from "@odata2ts/converter-api";
-import { bigNumberConverter } from "./BigNumberConverter";
+import { bigNumberConverter } from "./BigNumberConverter.js";
 
 const pkg: ConverterPackage = {
   id: "BigNumber",

--- a/packages/converter-big-number/tsconfig.esm.json
+++ b/packages/converter-big-number/tsconfig.esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Bundler resolution picks the "import" condition, so bignumber.js resolves to its ESM
+    // declarations here - which is the entire point: an ESM consumer has to end up with the same
+    // `BigNumber` class declaration this build was compiled against, or the private `_isBigNumber`
+    // makes the two mutually unassignable.
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "lib/esm"
+  }
+}


### PR DESCRIPTION
Follow-up to #64, which fixed the declared type but not the module-format half of the problem.

bignumber.js v11 ships separate type declarations per module format, and its class carries a private member:

```ts
declare class BigNumber implements BigNumber.Instance {
  private readonly _isBigNumber: true;
```

TypeScript therefore treats the class from `bignumber.d.cts` and the one from `bignumber.d.mts` as different types — *"Types have separate declarations of a private property `_isBigNumber`"*. This package was CommonJS only, so its `convertFrom` returned the CJS `BigNumber` while an ESM consumer's model property was typed on the ESM one:

```
Type 'PrimitiveTypeServiceV2<import("bignumber.js")>' is not assignable to type
'PrimitiveTypeServiceV2<import("bignumber.js", { with: { "resolution-mode": "import" } }).BigNumber>'
```

Every generated odata2ts client is ESM (`int-test/olingo-v2`, `int-test/cap`, `examples/main` are all `"type": "module"`), so the converter was effectively unusable there.

- The ESM build resolves bignumber.js through the `import` condition and so compiles against the same declaration an ESM consumer sees. `moduleResolution: Bundler` is what picks that condition — `NodeNext` would decide by this package's own `"type": "commonjs"` and emit CJS either way.
- `src/index.ts`'s relative import gained its `.js` extension, which both formats accept.
- `exports` maps `import`/`require` to the two builds; `lib/esm/package.json` marks the ESM output as such.

**Why not `BigNumber.Instance`:** that would also have compiled, since an interface has no private members — but `Instance` declares only `c`/`e`/`s` plus an index signature, so every method call on a converted value would silently become `any`. Checked with the compiler: `asInstance.toFixed(2)` is `any`, `asClass.toFixed(2)` is `string`.

**Verified** from a probe project in both formats: types check and `toFixed` stays `string` under ESM and CJS, and both entry points load and convert at runtime. The lasting regression guard is odata2ts' `yarn test-compile`, which type-checks the ESM generated clients against this package — it is red today and should go green with this release.

Only this package is affected; luxon, decimal and common type-check across the boundary today.
